### PR TITLE
feat: 多部件 AND 組合搜尋（v1.1.0）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-27
+
+### Added
+
+- **多部件組合搜尋** — 搜尋欄輸入多個漢字部件（如「氵木」）即搜尋「同時包含所有部件」的字。採遞迴比對：部件藏在更深層也算（如「淋」=⿰氵林，木在林裡仍算含木）；重複部件代表「至少 N 個」（如「木木」找含兩個以上木的字）
+- **多部件模式呈現** — 中欄列出輸入部件（首行為原始輸入，可點選切換「交集」與「單部件衍生字」視角）、右欄列出交集結果、左欄初始空白待點選某字才填
+- **多部件自動鎖定** — 進入多部件模式時自動勾選並鎖定「衍生字」與「深度拆解」開關（多部件本質為遞迴衍生字邏輯），離開時恢復原設定
+- **多部件筆畫篩選** — 筆畫滑桿在多部件模式以「各輸入部件筆畫數加總」為基準篩選交集結果（如「氵木」= 3+4 = 7 畫）
+
+### Internal
+
+- 新增 `search_all`（遞迴展開至葉部件 + 多重集計數包含）、`filter_by_stroke_value`（數值基準筆畫篩選，`filter_by_strokes` 重用之），以及 lazy 葉部件反向索引（首次建立後快取）
+
 ## [1.0.3] - 2026-04-11
 
 ### Added

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>Hanzi IDS Component Explorer</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>4</string>
 	<key>NSHumanReadableCopyright</key>

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -154,6 +154,12 @@ class HanziComponentSearchTool:
         self.deep_analysis = self.settings.get("deepAnalysis", False)
         self.show_derived = False
 
+        # 多部件 AND 搜尋模式狀態
+        self.multi_component_mode = False  # 是否處於多部件模式
+        self.multi_component_parts = []  # 當前輸入的部件清單（用於回到交集視角）
+        self.saved_show_derived = False  # 進入多部件模式前的衍生字開關，離開時恢復
+        self.saved_deep_analysis = False  # 進入多部件模式前的深度拆解開關，離開時恢復
+
         # 自動抓取設定（固定為 True）
         self.auto_fetch_enabled = True
         self.last_glyph_name = None
@@ -749,9 +755,15 @@ class HanziComponentSearchTool:
             # 手動模式：使用搜尋框內容
             self.current_char = None  # 清除自動模式的字符
 
-            # 多字輸入時只取第一個字（Issue #31）
-            if len(input_text) > 1 and ord(input_text[0]) > 127:
-                input_text = input_text[0]
+            # 多部件 AND 搜尋：輸入多個漢字時，進入多部件模式（中欄列部件、右欄列交集）
+            # 原本只取第一字（Issue #31），改為 AND 組合；無條件觸發，不受衍生字開關限制
+            parts = [c for c in input_text if not c.isspace()]
+            if len(parts) > 1 and all(ord(c) > 127 for c in parts):
+                self._enter_multi_component_mode(parts)
+                return
+
+        # 非多部件輸入：若先前在多部件模式，退出以恢復衍生字開關狀態
+        self._exit_multi_component_mode()
 
         # 處理 Unicode 格式
         if input_text.startswith(("uni", "UNI")) and len(input_text) == 7:
@@ -808,6 +820,13 @@ class HanziComponentSearchTool:
                 else:
                     return  # 找不到結果，保持原顯示
 
+        self._render_results()
+
+    def _render_results(self):
+        """將 self.all_results 渲染到中欄列表，並以第一個有效字更新左/右欄。
+
+        供單字、Unicode、多部件 AND 三條搜尋路徑共用。
+        """
         # 生成顯示結果並同時存儲
         self.display_results = [
             f"{tree}{content}" for tree, content in self.all_results
@@ -815,11 +834,91 @@ class HanziComponentSearchTool:
         self.w.resultList.set(self.display_results)
         self._adjust_result_list_column_width()
 
-        # 提取第一個有效字符
+        # 提取第一個有效字符，連動更新左欄（預覽+詳資）與右欄（同字根）
         if self.all_results:
             first_char = self._extract_valid_character_from_results(self.all_results)
             if first_char:
                 self.update_char_info(first_char)
+
+    # === 多部件 AND 搜尋模式 ===
+
+    def _enter_multi_component_mode(self, parts):
+        """進入多部件 AND 模式：中欄列輸入部件、右欄列交集、鎖定衍生字開關。
+
+        中欄第一行為原始輸入（AND 交集錨點），其後一行一個部件；
+        點選第一行回到交集、點選部件看該部件衍生字（見 selection_callback）。
+
+        parts: 輸入部件清單，保留原始輸入（已過濾空白，如 ['氵', '木']）
+        """
+        # 鎖定衍生字與深度拆解開關：多部件搜尋本質為衍生字邏輯的 AND 版本，
+        # 且交集以「遞迴展開到葉部件」為基礎，深度拆解恆為開啟
+        if not self.multi_component_mode:
+            self.saved_show_derived = self.show_derived
+            self.saved_deep_analysis = self.deep_analysis
+        self.multi_component_mode = True
+        self.multi_component_parts = parts
+        self.show_derived = True
+        self.w.showDerivedCheckbox.set(True)
+        self.w.showDerivedCheckbox.enable(False)
+        self.deep_analysis = True
+        self.w.deepAnalysisCheckbox.set(True)
+        self.w.deepAnalysisCheckbox.enable(False)
+
+        # 中欄：第一行原始輸入（交集錨點），其後一行一個部件
+        original = "".join(parts)
+        self.display_results = [original] + parts
+        self.w.resultList.set(self.display_results)
+        self._adjust_result_list_column_width()
+
+        # 右欄：AND 交集；左欄：清空，待點選中欄某字才填
+        self._render_intersection(parts)
+        self._clear_left_panel()
+
+    def _exit_multi_component_mode(self):
+        """離開多部件模式：解鎖並恢復衍生字與深度拆解開關的原設定。"""
+        if not self.multi_component_mode:
+            return
+        self.multi_component_mode = False
+        self.multi_component_parts = []
+        self.show_derived = self.saved_show_derived
+        self.w.showDerivedCheckbox.enable(True)
+        self.w.showDerivedCheckbox.set(self.show_derived)
+        self.deep_analysis = self.saved_deep_analysis
+        self.w.deepAnalysisCheckbox.enable(True)
+        self.w.deepAnalysisCheckbox.set(self.deep_analysis)
+
+    def _render_intersection(self, parts):
+        """將「同時包含所有 parts 部件」的交集字渲染到右欄。
+
+        套用筆畫篩選時，基準為所有輸入部件的筆畫數加總（如 氵木 = 3+4 = 7）；
+        任一部件無筆畫資料則不篩選（回退全顯示）。
+        """
+        charset = self.currentCharset if self.currentCharset else None
+        related = self.core.search_all(parts, charset)
+
+        # 筆畫篩選：基準 = 各輸入部件筆畫數加總
+        max_diff = self._stroke_filter_max_diff()
+        if max_diff is not None:
+            part_strokes = [self.core.get_stroke_count(p) for p in parts]
+            if None not in part_strokes:
+                base = sum(s for s in part_strokes if s is not None)
+                related = self.core.filter_by_stroke_value(related, base, max_diff)
+
+        display_text = self.core.clean_display_text("".join(related))
+        attr_string = self.create_attributed_string(
+            display_text, RELATED_CHARS_FONT_SIZE, use_enhanced_spacing=True
+        )
+        text_view = self.w.relatedChars.getNSTextView()
+        text_view.textStorage().setAttributedString_(attr_string)
+
+    def _clear_left_panel(self):
+        """清空左欄（預覽 + 詳資）；多部件模式無單一焦點字時使用。"""
+        self.current_char = None
+        self.w.preview.set("")
+        self.w.content.set("")
+        self.w.idsSwitcher.show(False)
+        if hasattr(self.w, "cnsLinkButton"):
+            self.w.cnsLinkButton.enable(False)
 
     def _extract_valid_character_from_results(self, results: List) -> Optional[str]:
         """從搜尋結果中提取有效字符"""
@@ -930,20 +1029,33 @@ class HanziComponentSearchTool:
         - 漢字：只更新右側相關字區域，左側保持不變
         """
         selection = sender.getSelection()
-        if selection:
-            selected_item = sender[selection[0]]
+        if not selection:
+            return
+        selected_item = sender[selection[0]]
 
-            # 使用 core 的字符提取邏輯
-            char = self.core.extract_character(selected_item)
+        # 多部件模式：第一行＝原始查詢（回到 AND 交集）；其餘行＝單一部件（看該部件衍生字）
+        if self.multi_component_mode:
+            if selected_item == "".join(self.multi_component_parts):
+                self._render_intersection(self.multi_component_parts)
+                self._clear_left_panel()
+            else:
+                char = self.core.extract_character(selected_item)
+                if char and self.core.is_valid_character(char):
+                    # 更新左欄（該部件資訊）與右欄（該部件衍生字，因開關已鎖定為開）
+                    self.update_char_info(char)
+            return
 
-            # IDC 符號不執行任何動作
-            idc_chars = "⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻〾"
-            if char in idc_chars:
-                return
+        # 使用 core 的字符提取邏輯
+        char = self.core.extract_character(selected_item)
 
-            if char and self.core.is_valid_character(char):
-                # 只更新右側相關字區域，不更新左側
-                self.update_related_display(char)
+        # IDC 符號不執行任何動作
+        idc_chars = "⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻〾"
+        if char in idc_chars:
+            return
+
+        if char and self.core.is_valid_character(char):
+            # 只更新右側相關字區域，不更新左側
+            self.update_related_display(char)
 
     def update_char_info(self, char):
         """更新字符資訊（支援 IDS 切換）"""
@@ -1266,7 +1378,10 @@ class HanziComponentSearchTool:
         self.stroke_filter_tick = new_tick
         self.settings.set("strokeFilterTick", new_tick)
         self._refresh_stroke_filter_display()
-        self.update_related_display()
+        if self.multi_component_mode:
+            self._render_intersection(self.multi_component_parts)
+        else:
+            self.update_related_display()
 
     def update_related_display(self, char=None):
         """

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -13,6 +13,7 @@ import re
 import gzip
 import pickle
 import unicodedata
+from collections import Counter
 from typing import Dict, List, Tuple, Union, Optional, Set
 from pathlib import Path
 
@@ -175,6 +176,9 @@ class HanziCore:
                     comp = _normalize_cjk_variant(comp)
                     self._component_index.setdefault(comp, set()).add(char)
 
+        # 葉部件反向索引（lazy 建立，見 _ensure_leaf_index）
+        self._leaf_index: Optional[Dict[str, Set[str]]] = None
+
     # === 字符查詢 ===
 
     def get_data(self, char_or_code: str) -> Dict[str, Dict[str, str]]:
@@ -265,15 +269,35 @@ class HanziCore:
         - 主字無筆畫資料時，回退為全顯示（避免空白面板）
         - max_diff 不為 None 時，無筆畫資料的字一律排除
         """
-        chars_list = list(chars)
-
-        # 不篩選 → 直接回傳
-        if max_diff is None:
-            return chars_list
-
-        # 主字無資料 → 回退為全顯示
         base_strokes = self.get_stroke_count(base_char)
-        if base_strokes is None:
+        # 主字無資料且要篩選 → 回退全顯示（避免空白面板）
+        if max_diff is not None and base_strokes is None:
+            return list(chars)
+        return self.filter_by_stroke_value(chars, base_strokes, max_diff)
+
+    def filter_by_stroke_value(
+        self,
+        chars,
+        base_strokes: Optional[int],
+        max_diff: Optional[int],
+    ) -> List[str]:
+        """
+        依筆畫差距篩選字符列表（數值基準版）
+
+        多部件搜尋以「各部件筆畫加總」為基準時使用此版本。
+
+        參數:
+        chars: 待篩選的字符 iterable
+        base_strokes (Optional[int]): 比較基準筆畫數
+        max_diff (Optional[int]):
+            None 或 base_strokes 為 None → 不篩選，全部回傳
+            int → 只保留筆畫差 ≤ max_diff 的字（無筆畫資料的字一律排除）
+
+        回傳:
+        List[str]: 篩選後的字符列表，順序與輸入一致
+        """
+        chars_list = list(chars)
+        if max_diff is None or base_strokes is None:
             return chars_list
 
         result = []
@@ -379,6 +403,103 @@ class HanziCore:
             results = [c for c in results if c in charset]
 
         return results
+
+    def search_all(
+        self, queries: List[str], charset: Optional[Set[str]] = None
+    ) -> List[str]:
+        """
+        多部件 AND 搜尋：回傳「遞迴展開到葉部件後，計數涵蓋查詢多重集」的字
+
+        語意：
+        - 遞迴：部件藏在更深層也算（如 淋=⿰氵林，木在林裡 → 視為含木）
+        - 計數：重複部件代表「至少 N 個」（如 木木 = 至少兩個木，林/森入選）
+
+        參數:
+        queries (List[str]): 部件清單，保留重複（重複代表次數要求）
+        charset (Optional[Set[str]]): 可選的字符集篩選（None = 搜尋全部）
+
+        回傳:
+        List[str]: 命中字，按 Unicode 碼位升序（確定性，使「前 N 個」可預期）
+        """
+        if not queries:
+            return []
+
+        # 查詢部件正規化後建多重集（與葉索引正規化一致）
+        query_counter = Counter(_normalize_cjk_variant(q) for q in queries)
+
+        leaf_index = self._ensure_leaf_index()
+
+        # 候選 = 同時（遞迴）含所有查詢部件的字，用葉反向索引快速縮小交集
+        unique_parts = list(query_counter)
+        candidates = set(leaf_index.get(unique_parts[0], set()))
+        for part in unique_parts[1:]:
+            candidates &= leaf_index.get(part, set())
+            if not candidates:
+                return []
+
+        # 計數驗證：每個查詢部件的葉計數需 >= 要求次數
+        results = []
+        for char in candidates:
+            leaves = self._leaf_components(char)
+            if all(leaves.get(part, 0) >= n for part, n in query_counter.items()):
+                results.append(char)
+
+        if charset is not None:
+            results = [c for c in results if c in charset]
+
+        return sorted(results, key=ord)
+
+    def _ensure_leaf_index(self) -> Dict[str, Set[str]]:
+        """首次需要時建立葉部件反向索引（leaf → 含該葉部件的字集合），建立後快取。"""
+        if self._leaf_index is None:
+            index: Dict[str, Set[str]] = {}
+            for char in self.db:
+                for leaf in self._leaf_components(char):
+                    index.setdefault(leaf, set()).add(char)
+            self._leaf_index = index
+        return self._leaf_index
+
+    def _leaf_components(self, char: str, max_depth: int = 20) -> Counter:
+        """遞迴展開字到葉部件，回傳多重集計數（Counter）。
+
+        葉部件＝獨體字 / 不在資料庫 / IDS 即自身者；含循環防護與深度上限，
+        葉部件做 CJK 變體正規化（與反向索引一致）。
+        """
+        counter: Counter = Counter()
+        self._collect_leaves(char, 0, max_depth, frozenset(), counter)
+        return counter
+
+    def _collect_leaves(self, char, depth, max_depth, visiting, counter):
+        """_leaf_components 的遞迴內部實作。"""
+        data = self.db.get(char)
+        ids = data.get("ids_1") if data else None
+
+        # 葉節點：超過深度 / 無資料 / 無 IDS / IDS 即自身 / 獨體字（無 IDC）
+        if (
+            depth >= max_depth
+            or not ids
+            or ids == char
+            or all(idc not in ids for idc in IDC_CHARS)
+        ):
+            counter[_normalize_cjk_variant(char)] += 1
+            return
+
+        components = [
+            c
+            for c in self.parse_ids(ids)[0]
+            if c not in IDC_CHARS and not c.startswith("&")
+        ]
+        if not components:
+            counter[_normalize_cjk_variant(char)] += 1
+            return
+
+        for comp in components:
+            if comp == char or comp in visiting:
+                counter[_normalize_cjk_variant(comp)] += 1
+            else:
+                self._collect_leaves(
+                    comp, depth + 1, max_depth, visiting | {char}, counter
+                )
 
     def find_sister_characters(
         self, char: str, charset: Optional[Set[str]] = None, variant_index: int = 0
@@ -907,7 +1028,7 @@ def is_complete_search_input(text: str) -> bool:
     if not text:
         return False
 
-    # 漢字輸入（非 ASCII）- 接受單個或多個漢字，搜尋時會取第一個字
+    # 漢字輸入（非 ASCII）- 接受單個或多個漢字（多字觸發 AND 組合搜尋）
     if ord(text[0]) > 127:
         return True
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## 功能
 
 - **字符拆解** — 輸入漢字，視覺化顯示其部件樹狀結構
+- **多部件組合搜尋** — 輸入多個部件（如「氵木」）找出同時包含所有部件的字；採遞迴比對（部件藏在更深層也算，如「淋」含「木」），重複部件代表「至少 N 個」（如「木木」找含兩個以上木的字）
 - **同字根查詢** — 找出與本字結構相同的關聯字
 - **衍生字查詢** — 找出以本字為部件的衍生字
 - **字集篩選** — 預設顯示字型檔內的字，亦可使用自訂字集
@@ -38,6 +39,7 @@
 1. *視窗 > 漢字 IDS 部件查詢* 開啟視窗
 2. 在搜尋欄輸入漢字（如「森」）或 Unicode（如「68EE」）
 3. 查看拆解結果、同字根、衍生字
+4. 輸入多個部件（如「氵木」）搜尋同時包含所有部件的字：中欄列出輸入部件、右欄列出符合的字；此時筆畫篩選以各部件筆畫加總為基準（如「氵木」= 7 畫）
 
 ## 系統需求
 
@@ -80,6 +82,7 @@ A [Glyphs](https://glyphsapp.com/) font editor plugin for decomposing Chinese ch
 ## Features
 
 - **Character Decomposition** — Visualize the component tree structure of any Chinese character
+- **Multi-Component Search** — Enter multiple components (e.g. "氵木") to find characters containing all of them; uses recursive matching (a component nested deeper still counts, e.g. "淋" contains "木"), and repeated components mean "at least N" (e.g. "木木" finds characters with two or more 木)
 - **Sister Characters** — Find characters sharing the same structure
 - **Derived Characters** — Find characters using this character as a component
 - **Charset Filtering** — Filter by current font glyphs or custom charset
@@ -105,6 +108,7 @@ Download `HanziIDSComponentExplorer.glyphsPlugin` and double-click to install.
 1. Open *Window > HanziIDSComponentExplorer*
 2. Enter a Chinese character (e.g., "森") or Unicode (e.g., "68EE")
 3. View decomposition, sister characters, and derived characters
+4. Enter multiple components (e.g. "氵木") to find characters containing all of them: the middle column lists the input components, the right column lists the matches; stroke filtering then uses the sum of the components' stroke counts as the baseline (e.g. "氵木" = 7 strokes)
 
 ## Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hanzi-ids-component-explorer"
-version = "1.0.3"
+version = "1.1.0"
 description = "Glyphs plugin for exploring Chinese character IDS components"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_hanzi_core_search.py
+++ b/tests/test_hanzi_core_search.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""HanziCore 多部件 AND 搜尋（search_all）測試
+
+語意：將候選字「遞迴展開到葉部件」後，其部件計數需涵蓋查詢的多重集計數。
+- 遞迴：「淋」=⿰氵林，木藏在林裡（第二層），查「氵木」仍應命中（問題 1）。
+- 計數：查「木木」代表「至少兩個木」，林(2木)、森(3木) 命中，沐(1木) 不命中（問題 2）。
+以記憶體 fixture 精確控制多層部件結構，驗證遞迴展開與計數匹配。
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# 將外掛 Resources 目錄加入路徑
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import HanziCore  # noqa: E402
+
+
+def _make_core(records: dict) -> HanziCore:
+    """建立跳過檔案載入的 HanziCore（測試專用），直接注入內部格式資料庫。"""
+    core = HanziCore.__new__(HanziCore)
+    core.data_path = Path("__test_in_memory__")
+    core._parsed_ids_cache = {}
+    core.db = {}
+    for char, data in records.items():
+        core.db[char] = {
+            "unicode": data.get("unicode", ""),
+            "char": char,
+            "ids_1": data.get("ids_1", ""),
+            "ids_2": data.get("ids_2", ""),
+            "strokes": data.get("strokes"),
+        }
+    core._build_indexes()
+    return core
+
+
+@pytest.fixture
+def core_components():
+    """多層部件交集測試核心。
+
+    IDS 為測試構造（部件採常規漢字，不受 NFKC 正規化影響）。
+    遞迴展開到葉部件後的計數：
+        林 → {木:2}            （⿰木木）
+        沐 → {氵:1, 木:1}      （⿰氵木）
+        淋 → {氵:1, 木:2}      （⿰氵林 → 氵 + 木木，木藏在第二層）
+        森 → {木:3}            （⿱木林 → 木 + 木木）
+        村 → {木:1, 寸:1}      （⿰木寸）
+    """
+    return _make_core(
+        {
+            "木": {"unicode": "6728", "ids_1": "木"},
+            "氵": {"unicode": "6C35", "ids_1": "氵"},
+            "寸": {"unicode": "5BF8", "ids_1": "寸"},
+            "林": {"unicode": "6797", "ids_1": "⿰木木"},
+            "沐": {"unicode": "6C90", "ids_1": "⿰氵木"},
+            "淋": {"unicode": "6DCB", "ids_1": "⿰氵林"},
+            "森": {"unicode": "68EE", "ids_1": "⿱木林"},
+            "村": {"unicode": "6751", "ids_1": "⿰木寸"},
+        }
+    )
+
+
+class TestSearchAllRecursive:
+    """遞迴展開：木藏在更深層級時仍應命中（解決問題 1）"""
+
+    def test_matches_via_nested_component(self, core_components):
+        """「氵木」：淋=⿰氵林，木在第二層，仍應命中（連同直接含木的沐）"""
+        result = core_components.search_all(["氵", "木"])
+        assert set(result) == {"沐", "淋"}
+
+    def test_single_query_recursive_holders(self, core_components):
+        """單部件「木」：所有遞迴含木的字（含木自身，與 search 一致）。
+
+        淋=⿰氵林 透過林（⿰木木）遞迴含木，亦應命中。
+        """
+        assert set(core_components.search_all(["木"])) == {
+            "木",
+            "林",
+            "沐",
+            "淋",
+            "森",
+            "村",
+        }
+
+
+class TestSearchAllCounting:
+    """多重集計數：重複部件代表「至少 N 個」（解決問題 2）"""
+
+    def test_double_component_requires_at_least_two(self, core_components):
+        """「木木」= 至少兩個木：林(2)、淋(2)、森(3) 命中；沐(1)、村(1) 不命中"""
+        assert set(core_components.search_all(["木", "木"])) == {"林", "淋", "森"}
+
+    def test_triple_component_requires_at_least_three(self, core_components):
+        """「木木木」= 至少三個木：只有森(3) 命中"""
+        assert core_components.search_all(["木", "木", "木"]) == ["森"]
+
+    def test_mixed_count_and_distinct(self, core_components):
+        """「氵木木」= 氵≥1 且 木≥2：只有淋(氵1,木2) 命中；沐(木1) 不命中"""
+        assert core_components.search_all(["氵", "木", "木"]) == ["淋"]
+
+
+class TestSearchAllGeneral:
+    """通用契約：空輸入、charset、排序"""
+
+    def test_empty_queries_returns_empty(self, core_components):
+        assert core_components.search_all([]) == []
+
+    def test_empty_intersection_returns_empty(self, core_components):
+        """無字同時含氵與寸 → 空"""
+        assert core_components.search_all(["氵", "寸"]) == []
+
+    def test_charset_filter_applied(self, core_components):
+        """charset 篩選後只保留字集內的字"""
+        result = core_components.search_all(["木", "木"], charset={"林"})
+        assert result == ["林"]
+
+    def test_results_sorted_by_codepoint(self, core_components):
+        """結果按 Unicode 碼位升序"""
+        result = core_components.search_all(["木", "木"])
+        assert result == sorted(result, key=ord)

--- a/tests/test_hanzi_core_strokes.py
+++ b/tests/test_hanzi_core_strokes.py
@@ -191,3 +191,44 @@ class TestFilterByStrokes:
         result = core_with_strokes.filter_by_strokes(chars, base_char="二", max_diff=2)
         # base 二=2，±2 → 六(6) 不通過、一(1)、三(3)、二(2) 通過
         assert result == ["一", "三", "二"]
+
+
+class TestFilterByStrokeValue:
+    """測試 filter_by_stroke_value（數值基準篩選，多部件搜尋以部件筆畫加總為基準）"""
+
+    def test_none_max_diff_returns_all(self, core_with_strokes):
+        """max_diff=None → 不篩選，全部回傳"""
+        chars = ["一", "二", "三"]
+        assert core_with_strokes.filter_by_stroke_value(chars, 7, None) == chars
+
+    def test_none_base_returns_all(self, core_with_strokes):
+        """基準為 None（如部件無筆畫資料）→ 回退全顯示"""
+        chars = ["一", "二", "三"]
+        assert core_with_strokes.filter_by_stroke_value(chars, None, 2) == chars
+
+    def test_exact_match(self, core_with_strokes):
+        """base=7, max_diff=0 → 只保留 7 畫（七）"""
+        chars = ["一", "二", "三", "五", "六", "七", "十"]
+        assert core_with_strokes.filter_by_stroke_value(chars, 7, 0) == ["七"]
+
+    def test_within_range(self, core_with_strokes):
+        """base=4, max_diff=2 → 2~6 畫：二(2)、三(3)、五(4)、六(6)"""
+        chars = ["一", "二", "三", "五", "六", "七", "十"]
+        result = core_with_strokes.filter_by_stroke_value(chars, 4, 2)
+        assert result == ["二", "三", "五", "六"]
+
+    def test_excludes_missing_stroke_data(self, core_with_strokes):
+        """無筆畫資料的字一律排除"""
+        chars = ["一", "二", "無"]
+        result = core_with_strokes.filter_by_stroke_value(chars, 2, 1)
+        assert "無" not in result
+
+    def test_preserves_order(self, core_with_strokes):
+        """結果順序與輸入一致"""
+        chars = ["六", "一", "三", "二"]
+        # base=2 ±2 → 0~4：六(6) 排除；一(1)、三(3)、二(2) 通過
+        assert core_with_strokes.filter_by_stroke_value(chars, 2, 2) == [
+            "一",
+            "三",
+            "二",
+        ]


### PR DESCRIPTION
## Summary

搜尋欄輸入多個漢字部件時，搜尋「同時包含所有部件」的字（取代原本只搜第一字的行為）。

- **遞迴比對** — 部件藏在更深層也算（如「淋」=⿰氵林 含「木」）
- **計數語意** — 重複部件代表「至少 N 個」（如「木木」找含兩個以上木的字）
- **多部件模式 UI** — 中欄列輸入部件（首行為原始輸入，可點選切換「交集 / 單部件衍生字」視角）、右欄列交集結果、左欄初始空白待點選某字才填
- **自動鎖定** — 衍生字 + 深度拆解開關自動勾選並鎖定（多部件本質為遞迴衍生字邏輯）
- **筆畫篩選** — 以各輸入部件筆畫加總為基準（如「氵木」= 3+4 = 7 畫）

## 實作

- `hanzi_core`：`search_all`（遞迴展開至葉部件 + 多重集計數包含）、`filter_by_stroke_value`（數值基準筆畫篩選，`filter_by_strokes` 重用之）、lazy 葉部件反向索引（首次 0.53s、快取後 0.037s）
- `glyphs_ui`：多部件模式狀態機（`_enter`/`_exit`/`_render_intersection`/`_clear_left_panel`）、`selection_callback` 擴展、衍生字+深度拆解雙鎖定、筆畫滑桿多部件重渲染

## Test plan

- `pytest tests/` → **45 passed**（`search_all` 9 例：遞迴命中 / 計數至少 N / charset / 排序；`filter_by_stroke_value` 6 例）
- 實機資料庫驗證：氵木 → 273 字（含淋，沐 7 畫）、木木 → 含 ≥2 木（林森淋）、筆畫加總基準 7 畫篩選正確
- Glyphs 實機驗證 UI：雙鎖定、中欄部件清單、首行錨點切換、筆畫滑桿即時篩選

版本：1.0.3 → 1.1.0（semver minor）

closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
