### PR TITLE
fix(#13): 多部件搜尋支援可再拆的中間部件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-28
+
+### Fixed
+
+- **多部件搜尋可比對中間部件** — 修正多部件搜尋只比對「展開後的葉部件」，導致本身可再拆的中間部件無法當查詢詞的問題。現在「立里」找得到「童」（童=⿱立里）、「金童」找得到「鐘」（鐘=⿰金童）、「火林」找得到「焚」（焚=⿱林火）。原本「火木木」這類葉部件查詢不受影響
+
+### Internal
+
+- 將 `search_all` 使用的葉部件反向索引改為「全層級節點」反向索引：`_recursive_components`（拆解樹每個節點各計數一次，含中間部件與葉部件）、`_ensure_recursive_index`（取代 `_leaf_*` 系列）。對僅含原子部件的查詢，計數結果與舊葉索引完全相同（零回歸）
+
 ## [1.1.0] - 2026-05-27
 
 ### Added
@@ -75,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 字符數量：98,662 個
 - 多拆法字符：6,152 個（6.24%）
 
+[1.1.1]: https://github.com/yintzuyuan/HanziIDSComponentExplorer/releases/tag/v1.1.1
+[1.1.0]: https://github.com/yintzuyuan/HanziIDSComponentExplorer/releases/tag/v1.1.0
 [1.0.3]: https://github.com/yintzuyuan/HanziIDSComponentExplorer/releases/tag/v1.0.3
 [1.0.2]: https://github.com/yintzuyuan/HanziIDSComponentExplorer/releases/tag/v1.0.2
 [1.0.0]: https://github.com/yintzuyuan/HanziIDSComponentExplorer/releases/tag/v1.0.0

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>Hanzi IDS Component Explorer</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2026 TzuYuan Yin</string>
 	<key>NSPrincipalClass</key>

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -176,8 +176,8 @@ class HanziCore:
                     comp = _normalize_cjk_variant(comp)
                     self._component_index.setdefault(comp, set()).add(char)
 
-        # 葉部件反向索引（lazy 建立，見 _ensure_leaf_index）
-        self._leaf_index: Optional[Dict[str, Set[str]]] = None
+        # 全層級部件反向索引（lazy 建立，見 _ensure_recursive_index）
+        self._recursive_index: Optional[Dict[str, Set[str]]] = None
 
     # === 字符查詢 ===
 
@@ -408,10 +408,11 @@ class HanziCore:
         self, queries: List[str], charset: Optional[Set[str]] = None
     ) -> List[str]:
         """
-        多部件 AND 搜尋：回傳「遞迴展開到葉部件後，計數涵蓋查詢多重集」的字
+        多部件 AND 搜尋：回傳「遞迴展開到所有層級部件後，計數涵蓋查詢多重集」的字
 
         語意：
         - 遞迴：部件藏在更深層也算（如 淋=⿰氵林，木在林裡 → 視為含木）
+        - 全層級：中間部件本身也可當查詢詞（如 童=⿱立里 → 視為含里；焚=⿱林火 → 視為含林）
         - 計數：重複部件代表「至少 N 個」（如 木木 = 至少兩個木，林/森入選）
 
         參數:
@@ -424,24 +425,24 @@ class HanziCore:
         if not queries:
             return []
 
-        # 查詢部件正規化後建多重集（與葉索引正規化一致）
+        # 查詢部件正規化後建多重集（與全層級索引正規化一致）
         query_counter = Counter(_normalize_cjk_variant(q) for q in queries)
 
-        leaf_index = self._ensure_leaf_index()
+        recursive_index = self._ensure_recursive_index()
 
-        # 候選 = 同時（遞迴）含所有查詢部件的字，用葉反向索引快速縮小交集
+        # 候選 = 同時（遞迴）含所有查詢部件的字，用全層級反向索引快速縮小交集
         unique_parts = list(query_counter)
-        candidates = set(leaf_index.get(unique_parts[0], set()))
+        candidates = set(recursive_index.get(unique_parts[0], set()))
         for part in unique_parts[1:]:
-            candidates &= leaf_index.get(part, set())
+            candidates &= recursive_index.get(part, set())
             if not candidates:
                 return []
 
-        # 計數驗證：每個查詢部件的葉計數需 >= 要求次數
+        # 計數驗證：每個查詢部件的全層級計數需 >= 要求次數
         results = []
         for char in candidates:
-            leaves = self._leaf_components(char)
-            if all(leaves.get(part, 0) >= n for part, n in query_counter.items()):
+            components = self._recursive_components(char)
+            if all(components.get(part, 0) >= n for part, n in query_counter.items()):
                 results.append(char)
 
         if charset is not None:
@@ -449,28 +450,34 @@ class HanziCore:
 
         return sorted(results, key=ord)
 
-    def _ensure_leaf_index(self) -> Dict[str, Set[str]]:
-        """首次需要時建立葉部件反向索引（leaf → 含該葉部件的字集合），建立後快取。"""
-        if self._leaf_index is None:
+    def _ensure_recursive_index(self) -> Dict[str, Set[str]]:
+        """首次需要時建立全層級部件反向索引（部件 → 含該部件的字集合），建立後快取。
+
+        收錄拆解樹中「所有層級的節點」（中間部件與葉部件皆是 key），
+        故可比對如「里」「童」「林」這類本身可再拆的中間部件。
+        """
+        if self._recursive_index is None:
             index: Dict[str, Set[str]] = {}
             for char in self.db:
-                for leaf in self._leaf_components(char):
-                    index.setdefault(leaf, set()).add(char)
-            self._leaf_index = index
-        return self._leaf_index
+                for comp in self._recursive_components(char):
+                    index.setdefault(comp, set()).add(char)
+            self._recursive_index = index
+        return self._recursive_index
 
-    def _leaf_components(self, char: str, max_depth: int = 20) -> Counter:
-        """遞迴展開字到葉部件，回傳多重集計數（Counter）。
+    def _recursive_components(self, char: str, max_depth: int = 20) -> Counter:
+        """遞迴展開字到所有層級部件，回傳多重集計數（Counter）。
 
-        葉部件＝獨體字 / 不在資料庫 / IDS 即自身者；含循環防護與深度上限，
-        葉部件做 CJK 變體正規化（與反向索引一致）。
+        拆解樹中每個節點（含中間部件與葉部件、含根字自身）各計數一次；
+        含循環防護與深度上限，部件做 CJK 變體正規化（與反向索引一致）。
         """
         counter: Counter = Counter()
-        self._collect_leaves(char, 0, max_depth, frozenset(), counter)
+        self._collect_recursive(char, 0, max_depth, frozenset(), counter)
         return counter
 
-    def _collect_leaves(self, char, depth, max_depth, visiting, counter):
-        """_leaf_components 的遞迴內部實作。"""
+    def _collect_recursive(self, char, depth, max_depth, visiting, counter):
+        """_recursive_components 的遞迴內部實作：對每個節點計數，再展開其子部件。"""
+        counter[_normalize_cjk_variant(char)] += 1
+
         data = self.db.get(char)
         ids = data.get("ids_1") if data else None
 
@@ -481,7 +488,6 @@ class HanziCore:
             or ids == char
             or all(idc not in ids for idc in IDC_CHARS)
         ):
-            counter[_normalize_cjk_variant(char)] += 1
             return
 
         components = [
@@ -489,15 +495,12 @@ class HanziCore:
             for c in self.parse_ids(ids)[0]
             if c not in IDC_CHARS and not c.startswith("&")
         ]
-        if not components:
-            counter[_normalize_cjk_variant(char)] += 1
-            return
 
         for comp in components:
             if comp == char or comp in visiting:
                 counter[_normalize_cjk_variant(comp)] += 1
             else:
-                self._collect_leaves(
+                self._collect_recursive(
                     comp, depth + 1, max_depth, visiting | {char}, counter
                 )
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## 功能
 
 - **字符拆解** — 輸入漢字，視覺化顯示其部件樹狀結構
-- **多部件組合搜尋** — 輸入多個部件（如「氵木」）找出同時包含所有部件的字；採遞迴比對（部件藏在更深層也算，如「淋」含「木」），重複部件代表「至少 N 個」（如「木木」找含兩個以上木的字）
+- **多部件組合搜尋** — 輸入多個部件（如「氵木」）找出同時包含所有部件的字；採遞迴比對（部件藏在更深層也算，如「淋」含「木」），可再拆的中間部件也能當查詢詞（如「立里」找到「童」、「火林」找到「焚」），重複部件代表「至少 N 個」（如「木木」找含兩個以上木的字）
 - **同字根查詢** — 找出與本字結構相同的關聯字
 - **衍生字查詢** — 找出以本字為部件的衍生字
 - **字集篩選** — 預設顯示字型檔內的字，亦可使用自訂字集
@@ -82,7 +82,7 @@ A [Glyphs](https://glyphsapp.com/) font editor plugin for decomposing Chinese ch
 ## Features
 
 - **Character Decomposition** — Visualize the component tree structure of any Chinese character
-- **Multi-Component Search** — Enter multiple components (e.g. "氵木") to find characters containing all of them; uses recursive matching (a component nested deeper still counts, e.g. "淋" contains "木"), and repeated components mean "at least N" (e.g. "木木" finds characters with two or more 木)
+- **Multi-Component Search** — Enter multiple components (e.g. "氵木") to find characters containing all of them; uses recursive matching (a component nested deeper still counts, e.g. "淋" contains "木"), decomposable intermediate components also work as queries (e.g. "立里" finds "童", "火林" finds "焚"), and repeated components mean "at least N" (e.g. "木木" finds characters with two or more 木)
 - **Sister Characters** — Find characters sharing the same structure
 - **Derived Characters** — Find characters using this character as a component
 - **Charset Filtering** — Filter by current font glyphs or custom charset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hanzi-ids-component-explorer"
-version = "1.1.0"
+version = "1.1.1"
 description = "Glyphs plugin for exploring Chinese character IDS components"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_hanzi_core_search.py
+++ b/tests/test_hanzi_core_search.py
@@ -127,3 +127,56 @@ class TestSearchAllGeneral:
         """結果按 Unicode 碼位升序"""
         result = core_components.search_all(["木", "木"])
         assert result == sorted(result, key=ord)
+
+
+@pytest.fixture
+def core_intermediate():
+    """中間部件交集測試核心。
+
+    中間部件＝本身可再拆、卻仍是常用查詢詞的部件（里、童、林）。
+    遞迴展開到「所有層級節點」後的計數（含中間節點與根字自身）：
+        里 → {里:1, 田:1, 土:1}                （⿱田土）
+        林 → {林:1, 木:2}                       （⿰木木）
+        童 → {童:1, 立:1, 里:1, 田:1, 土:1}      （⿱立里）
+        鐘 → {鐘:1, 金:1, 童:1, 立:1, 里:1, ...} （⿰金童，深層含立、里）
+        焚 → {焚:1, 林:1, 木:2, 火:1}            （⿱林火）
+    """
+    return _make_core(
+        {
+            "木": {"unicode": "6728", "ids_1": "木"},
+            "火": {"unicode": "706B", "ids_1": "火"},
+            "立": {"unicode": "7ACB", "ids_1": "立"},
+            "田": {"unicode": "7530", "ids_1": "田"},
+            "土": {"unicode": "571F", "ids_1": "土"},
+            "金": {"unicode": "91D1", "ids_1": "金"},
+            "里": {"unicode": "91CC", "ids_1": "⿱田土"},
+            "林": {"unicode": "6797", "ids_1": "⿰木木"},
+            "童": {"unicode": "7AE5", "ids_1": "⿱立里"},
+            "鐘": {"unicode": "9418", "ids_1": "⿰金童"},
+            "焚": {"unicode": "711A", "ids_1": "⿱林火"},
+        }
+    )
+
+
+class TestSearchAllIntermediateComponents:
+    """中間部件可比對：查詢詞本身可再拆時，仍應命中含它的字（修復回報的 bug）"""
+
+    def test_intermediate_component_li_matches_tong(self, core_intermediate):
+        """「立里」：里=⿱田土 是中間部件，童=⿱立里 應命中；鐘 深層亦含立、里"""
+        assert set(core_intermediate.search_all(["立", "里"])) == {"童", "鐘"}
+
+    def test_intermediate_component_tong_matches_zhong(self, core_intermediate):
+        """「金童」：童=⿱立里 是中間部件，鐘=⿰金童 應命中"""
+        assert core_intermediate.search_all(["金", "童"]) == ["鐘"]
+
+    def test_intermediate_component_lin_matches_fen(self, core_intermediate):
+        """「火林」：林=⿰木木 是中間部件，焚=⿱林火 應命中"""
+        assert core_intermediate.search_all(["火", "林"]) == ["焚"]
+
+    def test_leaf_path_still_matches_fen(self, core_intermediate):
+        """回歸：「火木木」走葉部件路徑仍命中焚（火≥1 且 木≥2）"""
+        assert core_intermediate.search_all(["火", "木", "木"]) == ["焚"]
+
+    def test_mixed_intermediate_and_leaf(self, core_intermediate):
+        """「木林」：木(葉)≥1 且 林(中間)≥1 → 林自身(木2,林1)與焚(木2,林1)命中"""
+        assert set(core_intermediate.search_all(["木", "林"])) == {"林", "焚"}


### PR DESCRIPTION
## Summary

修復多部件 AND 搜尋無法比對「可再拆的中間部件」的 bug。原本 `search_all` 走葉部件反向索引，中間部件（里→田土、童→立里、林→木木）在展開過程中消失，導致拿它們當查詢詞時交集永遠為空。

改用「全層級節點」索引：`_collect_recursive` 對拆解樹每個節點各計數一次（含中間部件、葉部件、根字自身），取代 `_leaf_*` 系列（依減法重構，改寫而非並存兩套）。

### 修復案例
- `立里` → `童`（童=⿱立里）
- `金童` → `鐘`（鐘=⿰金童）
- `火林` → `焚`（焚=⿱林火）

### 為何零回歸
原子部件（木、氵、火）永遠是葉、不會是中間節點，故只含原子部件的查詢計數與舊葉索引完全相同。全層級索引只是「額外」收錄中間部件 key。

## Test plan
- TDD 紅→綠：新增 5 個 `TestSearchAllIntermediateComponents` 中間部件測試
- 全套件 `uv run pytest`：**50 passed**，零回歸
- 實機完整資料庫（102,956 字）驗證：三案例命中，且 `氵木→淋`、`火木木→焚` 深層葉部件路徑回歸通過

## 版本
`1.1.0` → `1.1.1`（patch，pyproject + Info.plist + CHANGELOG）

closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)