### PR TITLE
fix(#17): 衍生字未勾選時恆顯示子部件同位（修正 #15 gate 回歸）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Language note**: From v1.2.0 onwards, CHANGELOG entries are written in English for international readers. Earlier entries (v1.0.x ~ v1.1.x) remain in Traditional Chinese.
 
+## [1.2.1] - 2026-06-04
+
+### Fixed
+
+- **Right panel went blank (showed only the character itself) when the "Derived characters" checkbox was unchecked** (#17) — Regression introduced in v1.2.0 (#15). The `update_related_display` rewrite accidentally gated the upper "Sub-component co-position" section behind the `show_derived` flag: its data source (`derived_groups`) was only computed when the checkbox was on, so unchecking it left both sections empty and the panel fell back to displaying the character alone. That upper section is the continuation of v1.1.x's always-shown "結構相同部件同位" tier and must not be gated. Fixed by extracting data selection into a unit-testable `HanziCore.resolve_related_sections`: the upper "Sub-component co-position" section is now always computed, and the checkbox only controls the lower "Containing-self compositions" section. Added regression-guard tests asserting the upper section stays non-empty regardless of the toggle. (Leaf components such as 言/金 have no upper section by design and still show only themselves when unchecked.)
+
 ## [1.2.0] - 2026-05-30
 
 ### Added

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -1444,14 +1444,13 @@ class HanziComponentSearchTool:
         lower_lines = []
         related_chars = set()
 
-        derived_groups = {}
-        if self.show_derived:
-            derived_groups = self.core.find_derived_characters(display_char, charset)
+        # 上半恆顯示、下半受衍生字開關控制（gate 已收斂進 resolver、修正 #17）
+        upper_pairs, lower_chars = self.core.resolve_related_sections(
+            display_char, charset, self.show_derived
+        )
 
         # 上半：子部件同位（display_char 頂層每個 Unicode operand 一行、filter 該位置同位的字）
-        for label, chars in self.core.compose_immediate_component_lines(
-            derived_groups, display_char
-        ):
+        for label, chars in upper_pairs:
             filtered = self._apply_chars_filters(
                 chars, display_char, related_chars, stroke_max_diff
             )
@@ -1459,10 +1458,9 @@ class HanziComponentSearchTool:
                 upper_lines.append(f"{label} {''.join(filtered)}")
                 related_chars.update(filtered)
 
-        # 下半：含本字作為部件的字（derived_groups[display_char]、按位置細分）
-        self_chars = derived_groups.get(display_char, [])
+        # 下半：含本字作為部件的字（resolver 已依 show_derived gate；沒勾選時 lower_chars 為 []）
         self_chars = self._apply_chars_filters(
-            self_chars, display_char, related_chars, stroke_max_diff
+            lower_chars, display_char, related_chars, stroke_max_diff
         )
         if self_chars:
             for label, chars in self.core.group_by_position(

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -1062,6 +1062,28 @@ class HanziCore:
 
         return derived_groups
 
+    def resolve_related_sections(
+        self,
+        display_char: str,
+        charset: Optional[Set[str]],
+        show_derived: bool,
+    ) -> Tuple[List[Tuple[str, List[str]]], List[str]]:
+        """解析右欄上下半的原始字集（未套 color / stroke filter）。
+
+        回 (upper_pairs, lower_chars)：
+        - upper_pairs: 子部件同位 [(label, [chars]), …]，恆計算（不受 show_derived 控制）
+        - lower_chars: 含本字整字的衍生字 list；show_derived=False 時為 []
+
+        修正 #17 回歸：上半同位字是 v1.1.x「結構相同部件同位」的延續、應恆顯示；
+        衍生字開關只控制下半「含本字組合」。
+        """
+        derived_groups = self.find_derived_characters(display_char, charset)
+        upper_pairs = self.compose_immediate_component_lines(
+            derived_groups, display_char
+        )
+        lower_chars = derived_groups.get(display_char, []) if show_derived else []
+        return upper_pairs, lower_chars
+
     # === 字符拆解 ===
 
     def decompose(

--- a/tests/test_classify_by_position.py
+++ b/tests/test_classify_by_position.py
@@ -544,3 +544,26 @@ class TestGroupByPositionCoarse:
         """coarse：鍂 = ⿰金金 仍歸 ⿰，不會升為 ⿰≡。"""
         groups = core_position.group_by_position(["鍂", "鐘"], ["金"], "coarse")
         assert groups == [("⿰", ["鍂", "鐘"])]  # 鍂 U+9342 < 鐘 U+9418
+
+
+class TestResolveRelatedSections:
+    """resolve_related_sections：右欄上下半資料選取 + 衍生字開關 gate。
+
+    回歸守護（#17）：v1.2.0(#15) 誤把「子部件同位」(上半) 也 gate 進
+    show_derived，導致沒勾選時右欄退回只顯示本字。語意：上半恆顯示、
+    開關只控制下半「含本字組合」。
+    """
+
+    def test_upper_always_shown_regardless_of_switch(self, core_position):
+        """子部件同位（上半）不受 show_derived 控制（修復前沒勾選會是 []）。"""
+        upper_off, _ = core_position.resolve_related_sections("鐘", None, False)
+        upper_on, _ = core_position.resolve_related_sections("鐘", None, True)
+        assert upper_off  # 沒勾選、上半仍非空 ← 捕捉 #17
+        assert upper_off == upper_on  # 上半不因開關改變
+
+    def test_lower_gated_by_switch(self, core_position):
+        """含本字組合（下半）受 show_derived 控制。"""
+        _, lower_off = core_position.resolve_related_sections("金", None, False)
+        _, lower_on = core_position.resolve_related_sections("金", None, True)
+        assert lower_off == []  # 沒勾選 → 下半空
+        assert set(lower_on)  # 勾選 → 下半非空（含金的字）


### PR DESCRIPTION
## Summary

修正 v1.2.0 (#15) 引入的回歸：未勾選「衍生字」勾選框時，右欄對任何字元只顯示本字自己。

**根因**：#15 重寫 `update_related_display` 時，把右欄上半「子部件同位」的資料源 `derived_groups` 也綁進了 `if self.show_derived` gate。該上半是 v1.1.x「結構相同部件同位」的延續、本應恆顯示；被 gate 後，未勾選時上下半皆空、右欄退回 `display_char`。

**結構性根因**：「開關控制右欄哪一半」這條邏輯從未被抽成可測單元，整個內聯在無法單元測試的 UI 方法裡；#15 的人工驗證又全在「勾選」狀態 → 單元測試缺口 + 驗證盲區雙重失守，回歸無聲通過。

**修復（減法重構）**：抽出可單元測試的 `HanziCore.resolve_related_sections(display_char, charset, show_derived)`——上半恆計算、開關只 gate 下半「含本字組合」；UI 的 color/stroke/related_chars filter 流程一字不動。並加回歸守護測試（未勾選時上半仍非空、且不隨開關改變），未來再把上半綁進開關會立即紅燈。

## Changes

- `hanzi_core.py`：新增 `HanziCore.resolve_related_sections`
- `glyphs_ui.py`：`update_related_display` 移除內聯 gate、改呼叫 resolver
- `tests/test_classify_by_position.py`：新增 `TestResolveRelatedSections`（2 測試）
- `CHANGELOG.md`：補 v1.2.1 Fixed 條目

## Test plan

- [x] `python3 -m pytest tests/` → **103 passed**（既有 101 + 新增 2）
- [ ] 實機（Glyphs.app）：
  1. 搜複合字「語」，**不勾選**衍生字 → 右欄顯示 `⿰1 …`/`⿰2 …` 子部件同位（不再只顯示「語」）
  2. 勾選衍生字 → 上半不變、額外出現 `---` + 含「語」整字的字
  3. 搜葉部件「言」不勾選 → 仍只顯示「言」（edge case，正確）；勾選後下半出現含言的字
  4. 多部件 AND 模式（如「氵木」）→ 行為不受影響
  5. 顏色 / 筆畫 / charset filter 對上下半仍正常套用

## Note

版本檔（pyproject / Info.plist）bump 與 release（tag / zip / gh release）依既有手動發布慣例，未含於本 PR。CHANGELOG 條目先標 [1.2.1] 待 release 對齊。

closes #17