### PR TITLE
feat(#19): PUA 造字各區正確顯示，含字型快取跨文件與重繪效能 hardening (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Language note**: From v1.2.0 onwards, CHANGELOG entries are written in English for international readers. Earlier entries (v1.0.x ~ v1.1.x) remain in Traditional Chinese.
 
+## [1.2.2] - 2026-06-29
+
+### Fixed
+
+- **Private-use (PUA) characters showed as tofu (missing-glyph boxes) throughout the plugin** (#19) — IDS-composed glyphs mapped to PUA codepoints (e.g. U+E000) have no script association in the system font cascade, so `CTFontCreateForString` cannot fall back to a user-made font by codepoint and every panel rendered tofu. Fixed by resolving, for any last-resort codepoint, an installed font that actually covers it: first the open document's same-named family, otherwise any installed font whose character set covers the codepoint (so an exported + installed font displays regardless of which document is open). The middle result list now draws per-character fonts via a custom cell, and the search field adopts the PUA-driving font, so PUA, Armenian, CJK and IDC symbols all render in their correct fonts. Pure decomposition/decision logic (`field_display_char`, `glyph_font_runs`) extracted and unit-tested.
+- **Wrong glyph shown after switching between documents that map the same PUA codepoint to different glyphs** — The font cache was keyed only by `(char, size)`, but last-resort resolution depends on the open document's family, so switching documents returned the previous document's cached font. The cache key now includes the document family name (`font_cache_key`).
+- **Scroll lag when results contained a PUA codepoint no installed font covers** — Such a codepoint was never cached, so every redraw (scroll, selection, focus) re-ran a brute-force scan over every installed font family on the main thread. A negative cache (`FontCache`) now records "no covering font" and short-circuits redraws; it is cleared on each new search so a font installed mid-session is retried. A non-covering same-named family is no longer returned as a positive result (would persist as sticky tofu).
+- **Supplementary-plane PUA codepoints mis-detected** — `CTFontCreateForString`'s range was computed with Python `len()` (codepoints) instead of UTF-16 code units, covering only the leading surrogate of astral characters. Fixed via `utf16_len`.
+
+### Internal
+
+- New unit-tested pure helpers in `hanzi_core`: `field_display_char`, `glyph_font_runs`, `font_cache_key`, `FontCache`, `choose_glyph_font_source`, `utf16_len`.
+
 ## [1.2.1] - 2026-06-04
 
 ### Fixed

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>Hanzi IDS Component Explorer</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2026 TzuYuan Yin</string>
 	<key>NSPrincipalClass</key>

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -32,10 +32,17 @@ from AppKit import (
     NSNotificationCenter,
     NSTableViewNoColumnAutoresizing,
     NSLineBreakByClipping,
+    NSTextFieldCell,
 )
 import CoreText
 
-from hanzi_core import HanziCore, is_complete_search_input, resolve_display_char
+from hanzi_core import (
+    HanziCore,
+    is_complete_search_input,
+    resolve_display_char,
+    field_display_char,
+    glyph_font_runs,
+)
 from glyphs_adapter import GlyphsAdapter, GlyphsSettings
 from localization import L
 
@@ -44,6 +51,7 @@ from localization import L
 RELATED_CHARS_FONT_SIZE = 20  # 右側相關字區域
 CONTENT_FONT_SIZE = 14  # 左側詳細資訊區
 RESULT_LIST_FONT_SIZE = 13  # 中間結果列表
+SEARCH_FIELD_FONT_SIZE = 13  # 頂部搜尋框（讓造字/部件在框內也能顯示）
 
 # 筆畫篩選滑桿設定
 # tick 0..4 對應筆畫差 ±0/±1/±2/±3/±5；tick 5 為「關閉篩選」
@@ -70,6 +78,36 @@ GLYPH_COLOR_MAP = {
     10: (0.75, 0.75, 0.75, 1.0),  # 淺灰
     11: (0.50, 0.50, 0.50, 1.0),  # 深灰
 }
+
+
+class _HanziListCellBase(NSTextFieldCell):
+    """中欄結果列表的自訂儲存格：逐字挑字型繪製。
+
+    vanilla.List 整欄只有單一字型，無法同時顯示 CJK／亞美尼亞／PUA 造字。
+    此儲存格改由 tool._build_list_attributed_string 組「逐字字型」的
+    NSAttributedString 來畫。tool 以實例屬性綁定（cell-based 表格繪製時
+    重用同一 dataCell，屬性得以保留）；任何例外都回退原生繪製，確保穩定。
+    """
+
+    def drawInteriorWithFrame_inView_(self, cellFrame, controlView):
+        tool = getattr(self, "tool", None)
+        try:
+            text = self.stringValue()
+            if tool is not None and text:
+                attr = tool._build_list_attributed_string(
+                    str(text), bool(self.isHighlighted())
+                )
+                text_height = attr.size().height
+                point = (
+                    cellFrame.origin.x + 2,
+                    cellFrame.origin.y
+                    + (cellFrame.size.height - text_height) / 2.0,
+                )
+                attr.drawAtPoint_(point)
+                return
+        except Exception:
+            pass
+        NSTextFieldCell.drawInteriorWithFrame_inView_(self, cellFrame, controlView)
 
 
 # 篩選選單處理器（使用獨立類別確保 ObjC 方法正確註冊）
@@ -166,6 +204,10 @@ class HanziComponentSearchTool:
         # 自動抓取設定（固定為 True）
         self.auto_fetch_enabled = True
         self.last_glyph_name = None
+        # 搜尋框目前字型所依據的字（避免每次重設造成閃爍）
+        self._search_field_font_char = None
+        # 已命中、能涵蓋造字的字型家族名（加速後續同類造字、消除掃描延遲）
+        self._covering_font_families = []
 
         # 模式切換：自動模式 vs 手動模式
         # 自動模式：選擇字符時清空搜尋框，使用多 Unicode 智能偵測
@@ -265,11 +307,15 @@ class HanziComponentSearchTool:
             (114, 60, 130, -42), [], selectionCallback=self.selection_callback
         )
 
-        # 為結果列表設定 TW-Sung 字型
+        # 為結果列表設定字型；改用逐字選字型的自訂儲存格，
+        # 讓造字（PUA）、亞美尼亞字母等也能在中欄列表顯示（單一欄字型無法 per-char）
         result_list_font = self.get_font_for_char("漢", RESULT_LIST_FONT_SIZE)
         tableView = self.w.resultList.getNSTableView()
         for column in tableView.tableColumns():
-            column.dataCell().setFont_(result_list_font)
+            cell = _HanziListCellBase.alloc().init()
+            cell.tool = self
+            cell.setFont_(result_list_font)  # 供寬度量測與後援繪製
+            column.setDataCell_(cell)
 
         # 啟用橫向捲軸：禁用欄位自動調整，讓欄位可以超出視窗寬度
         tableView.setColumnAutoresizingStyle_(NSTableViewNoColumnAutoresizing)
@@ -691,6 +737,7 @@ class HanziComponentSearchTool:
             if valid_char:
                 # 清空搜尋框
                 self.w.inputText.set("")
+                self._update_search_field_font()
 
                 # 設定當前字符並觸發搜尋（換主字 → reset 右欄子部件 sticky）
                 self.current_char = valid_char
@@ -716,9 +763,40 @@ class HanziComponentSearchTool:
             current_glyph = self.get_current_glyph()
             if current_glyph:
                 self.w.inputText.set(current_glyph)
+                self._update_search_field_font()
                 self.perform_search()
 
     # === 搜尋功能 ===
+
+    def _update_search_field_font(self, *args):
+        """依搜尋框內容動態設定欄位字型，讓 PUA 造字／部件也能在框內正確顯示。
+
+        整段非 ASCII → 用首字的解析字型（get_font_for_char 會解析到已安裝字型）；
+        含 ASCII（如 U+XXXX 查詢）→ 系統字型。以快取字避免重複設定造成閃爍。
+        """
+        try:
+            target = field_display_char(self.w.inputText.get())
+            if target == self._search_field_font_char:
+                return
+            self._search_field_font_char = target
+
+            # 取底層 NSSearchField（不同 vanilla 版本存取方式略異，逐一嘗試）
+            field = None
+            for accessor in ("getNSSearchField", "getNSTextField"):
+                if hasattr(self.w.inputText, accessor):
+                    field = getattr(self.w.inputText, accessor)()
+                    break
+            if field is None:
+                field = getattr(self.w.inputText, "_nsObject", None)
+            if field is None:
+                return
+
+            if target is not None:
+                field.setFont_(self.get_font_for_char(target, SEARCH_FIELD_FONT_SIZE))
+            else:
+                field.setFont_(NSFont.systemFontOfSize_(SEARCH_FIELD_FONT_SIZE))
+        except Exception:
+            pass
 
     def search_callback(self, sender):
         """
@@ -730,6 +808,8 @@ class HanziComponentSearchTool:
         """
         # 用戶開始輸入 → 進入手動模式
         input_text = self.w.inputText.get().strip()
+        # 依內容更新搜尋框字型（造字／部件可正確顯示）
+        self._update_search_field_font()
         if input_text:
             self.is_manual_mode = True
 
@@ -1558,9 +1638,17 @@ class HanziComponentSearchTool:
             del ps_name
 
             if is_last_resort:
-                # 釋放 fallback_ct_font（不使用，改用系統字型）
+                # 釋放 fallback_ct_font（不使用）
                 del fallback_ct_font
-                font = NSFont.systemFontOfSize_(size)
+                # PUA 造字等「系統 cascade 無法靠碼位 fallback」的字（如以 IDS 組出的
+                # U+E000）：先試開啟檔的同名字型，再掃所有已安裝字型找涵蓋此碼位者
+                # （只要系統裝了含該字的字型就顯示得出，不必是當前開啟的檔）。
+                installed = self._resolve_glyph_font(char, size)
+                if installed is None:
+                    # 系統無任何字型含此碼位 → 暫退系統字型（顯示為缺字框）。
+                    # 不寫入快取，待使用者安裝字型後重試即可正確顯示。
+                    return NSFont.systemFontOfSize_(size)
+                font = installed
             else:
                 # CTFont 和 NSFont 可透過 toll-free bridging 互轉
                 font = fallback_ct_font
@@ -1580,6 +1668,171 @@ class HanziComponentSearchTool:
         except Exception:
             # 發生錯誤時 fallback 到系統字型
             return NSFont.systemFontOfSize_(size)
+
+    def _resolve_installed_font(self, size):
+        """取得「目前 Glyphs 開啟字型同名的已安裝字型」NSFont，找不到回 None。
+
+        用途：PUA 造字（如以 IDS 組出的 U+E000）在系統 cascade 中沒有 script
+        關聯，CTFontCreateForString 無法靠碼位 fallback 到使用者自製字型，
+        因此需以字型「家族名稱」明確指定。前提：該字型已從 Glyphs 匯出並安裝，
+        且其家族名稱與目前開啟的 Glyphs 檔一致。
+        """
+        try:
+            gfont = self.adapter.get_current_font()
+            family = getattr(gfont, "familyName", None) if gfont else None
+            if not family:
+                return None
+            from AppKit import NSFontManager
+
+            # 以家族名稱取 Regular（weight 5）；失敗再退而用字型名稱直接查
+            ns_font = (
+                NSFontManager.sharedFontManager().fontWithFamily_traits_weight_size_(
+                    family, 0, 5, size
+                )
+            )
+            if ns_font is None:
+                ns_font = NSFont.fontWithName_size_(family, size)
+            return ns_font
+        except Exception:
+            return None
+
+    def _font_covers(self, ns_font, code_point):
+        """以字型的 character set 判定是否涵蓋該碼位（支援補充平面）。"""
+        try:
+            char_set = CoreText.CTFontCopyCharacterSet(ns_font)
+            if char_set is None:
+                return False
+            return bool(char_set.longCharacterIsMember_(code_point))
+        except Exception:
+            return False
+
+    def _font_covering_codepoint(self, code_point, size):
+        """回一個涵蓋該碼位的已安裝字型（不依賴目前開啟的 Glyphs 檔）；找不到回 None。
+
+        三段式以消除掃描延遲：
+        0) 先試先前已命中、涵蓋過造字的字型（同顆字型多半涵蓋整段 PUA → 瞬間命中）
+        1) 原生 font-descriptor 的 character set 比對（CoreText 內部比對，快）
+        2) 後援：逐一掃過所有已安裝字型家族（較慢，僅在前兩者都失敗時）
+        命中後記住其家族名，供後續造字快速命中。
+        """
+        # 0) 記憶命中
+        for family in self._covering_font_families:
+            ns_font = NSFont.fontWithName_size_(family, size)
+            if ns_font is not None and self._font_covers(ns_font, code_point):
+                return ns_font
+
+        # 1) 原生比對 → 2) 後援掃描
+        font = self._descriptor_match_font(code_point, size)
+        if font is None:
+            font = self._brute_force_covering_font(code_point, size)
+
+        if font is not None:
+            try:
+                family = font.familyName()
+                if family and family not in self._covering_font_families:
+                    self._covering_font_families.append(family)
+            except Exception:
+                pass
+        return font
+
+    def _descriptor_match_font(self, code_point, size):
+        """用 font descriptor 的 character set 屬性做原生比對，快速找涵蓋該碼位的字型。"""
+        if code_point > 0xFFFF:
+            # addCharactersInRange 以 UTF-16 計，補充平面不走此捷徑（交給後援掃描）
+            return None
+        try:
+            from AppKit import NSFontDescriptor, NSFontCharacterSetAttribute
+            from Foundation import NSMutableCharacterSet, NSMakeRange, NSSet
+
+            charset = NSMutableCharacterSet.alloc().init()
+            charset.addCharactersInRange_(NSMakeRange(code_point, 1))
+            descriptor = NSFontDescriptor.fontDescriptorWithFontAttributes_(
+                {NSFontCharacterSetAttribute: charset}
+            )
+            mandatory = NSSet.setWithObject_(NSFontCharacterSetAttribute)
+            matches = descriptor.matchingFontDescriptorsWithMandatoryKeys_(mandatory)
+            if matches:
+                for matched in matches:
+                    ns_font = NSFont.fontWithDescriptor_size_(matched, size)
+                    if ns_font is not None and self._font_covers(ns_font, code_point):
+                        return ns_font
+        except Exception:
+            pass
+        return None
+
+    def _brute_force_covering_font(self, code_point, size):
+        """後援：逐一掃過所有已安裝字型家族，找第一個涵蓋該碼位者。"""
+        try:
+            from AppKit import NSFontManager
+
+            manager = NSFontManager.sharedFontManager()
+            for family in manager.availableFontFamilies():
+                ns_font = NSFont.fontWithName_size_(family, size)
+                if ns_font is None:
+                    members = manager.availableMembersOfFontFamily_(family)
+                    if members and len(members) > 0:
+                        ns_font = NSFont.fontWithName_size_(members[0][0], size)
+                if ns_font is not None and self._font_covers(ns_font, code_point):
+                    return ns_font
+        except Exception:
+            pass
+        return None
+
+    def _resolve_glyph_font(self, char, size):
+        """為缺字（LastResort）的字解析能顯示它的已安裝字型，找不到回 None。
+
+        順序：
+        1) 目前開啟的 Glyphs 檔同名安裝字型，且確認真的涵蓋此字 → 直接用（編輯中優先）
+        2) 掃所有已安裝字型取涵蓋此碼位者（與開哪個檔無關 → 安裝了就能顯示）
+        3) 後援：開啟檔的同名字型（保留舊行為，至少編輯該字型時可顯示）
+        """
+        code_point = ord(char[0]) if char else None
+        family_font = self._resolve_installed_font(size)
+
+        if (
+            family_font is not None
+            and code_point is not None
+            and self._font_covers(family_font, code_point)
+        ):
+            return family_font
+
+        if code_point is not None:
+            covering = self._font_covering_codepoint(code_point, size)
+            if covering is not None:
+                return covering
+
+        return family_font
+
+    def _build_list_attributed_string(self, text, highlighted=False):
+        """為中欄結果列表逐字挑字型，組 NSAttributedString。
+
+        以 glyph_font_runs 分段：非 ASCII 字逐字經 get_font_for_char 解析
+        （PUA→已安裝字型、亞美尼亞→系統亞美尼亞字型、CJK→CJK 字型、樹狀符號
+        →相應字型）；連續 ASCII 用系統字型一段帶過。選取列用反白文字色，
+        其餘用語義標籤色（自動深淺模式）。
+        """
+        result = NSMutableAttributedString.alloc().init()
+        color = (
+            NSColor.alternateSelectedControlTextColor()
+            if highlighted
+            else NSColor.labelColor()
+        )
+        base_font = NSFont.systemFontOfSize_(RESULT_LIST_FONT_SIZE)
+        for segment, needs_glyph in glyph_font_runs(text):
+            if needs_glyph:
+                font = self.get_font_for_char(segment, RESULT_LIST_FONT_SIZE)
+            else:
+                font = base_font
+            result.appendAttributedString_(
+                NSAttributedString.alloc().initWithString_attributes_(
+                    segment,
+                    {
+                        NSFontAttributeName: font,
+                        NSForegroundColorAttributeName: color,
+                    },
+                )
+            )
+        return result
 
     def create_attributed_string(self, text, size, use_enhanced_spacing=False):
         """
@@ -1623,8 +1876,9 @@ class HanziComponentSearchTool:
                 or 0x2FF0 <= code_point <= 0x2FFF  # IDC（表意文字描述字符 ⿰⿱⿲）
                 or 0x3400 <= code_point <= 0x4DBF  # CJK Extension A
                 or 0x4E00 <= code_point <= 0x9FFF  # CJK Unified Ideographs
+                or 0xE000 <= code_point <= 0xF8FF  # PUA（造字／IDS 組字，依賴已安裝字型）
                 or 0xF900 <= code_point <= 0xFAFF  # CJK Compatibility Ideographs
-                or code_point >= 0x20000  # CJK Extension B-H+
+                or code_point >= 0x20000  # CJK Extension B-H+（含補充平面 PUA）
             )
             if is_cjk_related:
                 font = self.get_font_for_char(char, size)

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -42,6 +42,10 @@ from hanzi_core import (
     resolve_display_char,
     field_display_char,
     glyph_font_runs,
+    font_cache_key,
+    FontCache,
+    choose_glyph_font_source,
+    utf16_len,
 )
 from glyphs_adapter import GlyphsAdapter, GlyphsSettings
 from localization import L
@@ -172,9 +176,10 @@ SelectionObserverHandler = type(
 class HanziComponentSearchTool:
     """Glyphs 外掛主視窗"""
 
-    # 字型快取（類別層級）
-    _font_cache = {}  # key: (char, size), value: NSFont
+    # 字型快取（類別層級）：正向（鍵→NSFont）＋負向（已知無涵蓋字型）
+    # 鍵為 font_cache_key(char, size, font_family)
     _CACHE_MAX_SIZE = 500  # 最大快取數量
+    _font_cache = FontCache(_CACHE_MAX_SIZE)
 
     def __init__(self, title=None):
         # === 初始化核心引擎 ===
@@ -826,6 +831,10 @@ class HanziComponentSearchTool:
         自動模式：使用 self.current_char（已由 on_glyph_changed 設定）
         手動模式：使用搜尋框內容
         """
+        # 新搜尋時清掉負向字型快取：若使用者期間安裝了含某 PUA 的字型，
+        # 讓該碼位重新解析以正確顯示（正向快取保留，不影響效能）。
+        self._font_cache.forget_missing()
+
         input_text = self.w.inputText.get().strip()
 
         # 自動模式：搜尋框為空，使用 current_char
@@ -1608,10 +1617,16 @@ class HanziComponentSearchTool:
         if not char:
             return NSFont.systemFontOfSize_(size)
 
-        # 查詢快取
-        cache_key = (char, size)
-        if cache_key in self._font_cache:
-            return self._font_cache[cache_key]
+        # 查詢快取（鍵納入當前文件家族名：last_resort/PUA 解析依當前文件而定，
+        # 否則切換文件時同碼位會誤命中前一文件的陳舊字型，見 #19 回歸）
+        cache_key = font_cache_key(char, size, self._current_font_family())
+        state, cached = self._font_cache.lookup(cache_key)
+        if state == "hit":
+            return cached
+        if state == "missing":
+            # 已知系統無任何字型涵蓋此碼位 → 直接回系統字型，
+            # 不再重跑全字型暴力掃描（負向快取，消除重繪卡頓，見健檢 #1）
+            return NSFont.systemFontOfSize_(size)
 
         try:
             # 建立基礎 CTFont（系統 UI 字型包含完整的 cascade list）
@@ -1620,9 +1635,10 @@ class HanziComponentSearchTool:
             )
 
             # 使用 CTFontCreateForString 尋找能顯示該字符的字型
-            # range: (location, length)
+            # range 以 UTF-16 計量：補充平面字（如補充平面 PUA）需 utf16_len，
+            # 用 Python len() 只會涵蓋前導代理 → last_resort 偵測失準
             fallback_ct_font = CoreText.CTFontCreateForString(
-                base_ct_font, char, (0, len(char))
+                base_ct_font, char, (0, utf16_len(char))
             )
 
             # 釋放 base_ct_font（不再需要，避免記憶體洩漏）
@@ -1645,29 +1661,36 @@ class HanziComponentSearchTool:
                 # （只要系統裝了含該字的字型就顯示得出，不必是當前開啟的檔）。
                 installed = self._resolve_glyph_font(char, size)
                 if installed is None:
-                    # 系統無任何字型含此碼位 → 暫退系統字型（顯示為缺字框）。
-                    # 不寫入快取，待使用者安裝字型後重試即可正確顯示。
+                    # 系統無任何字型含此碼位 → 退系統字型（顯示為缺字框）並記住此鍵，
+                    # 避免每次重繪重跑暴力掃描；使用者安裝字型後由下次搜尋
+                    # forget_missing() 清掉負向項重試（見健檢 #1）。
+                    self._font_cache.store_missing(cache_key)
                     return NSFont.systemFontOfSize_(size)
                 font = installed
             else:
                 # CTFont 和 NSFont 可透過 toll-free bridging 互轉
                 font = fallback_ct_font
 
-            # 快取管理：超過上限時清除一半
-            if len(self._font_cache) >= self._CACHE_MAX_SIZE:
-                keys_to_remove = list(self._font_cache.keys())[
-                    : self._CACHE_MAX_SIZE // 2
-                ]
-                for key in keys_to_remove:
-                    del self._font_cache[key]
-
-            # 快取結果
-            self._font_cache[cache_key] = font
+            # 快取結果（容量管理由 FontCache 內部處理）
+            self._font_cache.store(cache_key, font)
             return font
 
         except Exception:
             # 發生錯誤時 fallback 到系統字型
             return NSFont.systemFontOfSize_(size)
+
+    def _current_font_family(self):
+        """目前開啟 Glyphs 文件的家族名；無文件、無名稱或取值失敗皆回 None。
+
+        集中此查找供字型快取鍵（font_cache_key）與已安裝字型解析共用，確保兩者對
+        「當前文件身分」的判定一致，避免快取鍵與解析來源各算一套造成跨文件陳舊命中。
+        """
+        try:
+            gfont = self.adapter.get_current_font()
+            family = getattr(gfont, "familyName", None) if gfont else None
+            return family or None
+        except Exception:
+            return None
 
     def _resolve_installed_font(self, size):
         """取得「目前 Glyphs 開啟字型同名的已安裝字型」NSFont，找不到回 None。
@@ -1677,11 +1700,10 @@ class HanziComponentSearchTool:
         因此需以字型「家族名稱」明確指定。前提：該字型已從 Glyphs 匯出並安裝，
         且其家族名稱與目前開啟的 Glyphs 檔一致。
         """
+        family = self._current_font_family()
+        if not family:
+            return None
         try:
-            gfont = self.adapter.get_current_font()
-            family = getattr(gfont, "familyName", None) if gfont else None
-            if not family:
-                return None
             from AppKit import NSFontManager
 
             # 以家族名稱取 Regular（weight 5）；失敗再退而用字型名稱直接查
@@ -1781,27 +1803,30 @@ class HanziComponentSearchTool:
     def _resolve_glyph_font(self, char, size):
         """為缺字（LastResort）的字解析能顯示它的已安裝字型，找不到回 None。
 
-        順序：
+        順序（優先序判定見 hanzi_core.choose_glyph_font_source）：
         1) 目前開啟的 Glyphs 檔同名安裝字型，且確認真的涵蓋此字 → 直接用（編輯中優先）
         2) 掃所有已安裝字型取涵蓋此碼位者（與開哪個檔無關 → 安裝了就能顯示）
-        3) 後援：開啟檔的同名字型（保留舊行為，至少編輯該字型時可顯示）
+        3) 都不涵蓋 → None（退系統字型、由負向快取記住待重試）。
+           不退回不涵蓋的同名字型，否則只是另一種豆腐且會被當正向結果快取。
         """
         code_point = ord(char[0]) if char else None
+        if code_point is None:
+            return None
+
         family_font = self._resolve_installed_font(size)
+        family_covers = family_font is not None and self._font_covers(
+            family_font, code_point
+        )
+        covering = (
+            None if family_covers else self._font_covering_codepoint(code_point, size)
+        )
 
-        if (
-            family_font is not None
-            and code_point is not None
-            and self._font_covers(family_font, code_point)
-        ):
+        choice = choose_glyph_font_source(family_covers, covering is not None)
+        if choice == "family":
             return family_font
-
-        if code_point is not None:
-            covering = self._font_covering_codepoint(code_point, size)
-            if covering is not None:
-                return covering
-
-        return family_font
+        if choice == "covering":
+            return covering
+        return None
 
     def _build_list_attributed_string(self, text, highlighted=False):
         """為中欄結果列表逐字挑字型，組 NSAttributedString。

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -108,6 +108,63 @@ def resolve_display_char(
     return sticky or current
 
 
+def _is_pua(code_point: int) -> bool:
+    """是否為 Private Use Area 碼位（BMP PUA 與兩個補充平面 PUA）。"""
+    return (
+        0xE000 <= code_point <= 0xF8FF
+        or 0xF0000 <= code_point <= 0xFFFFD
+        or 0x100000 <= code_point <= 0x10FFFD
+    )
+
+
+def field_display_char(text: Optional[str]) -> Optional[str]:
+    """決定搜尋框（NSSearchField）該以哪個字的字型渲染，無則回 None（用系統字型）。
+
+    NSSearchField 整欄只能用單一字型，故策略為：
+    1) 框內含造字（PUA）→ 用第一個 PUA 字驅動（系統字型必缺這些字、且單一字型
+       只能擇一，造字最該優先顯示，避免被前導 ASCII／CJK 蓋過）；
+    2) 否則整段皆非 ASCII（CJK／亞美尼亞等同書寫系統）→ 用首字；
+    3) 含 ASCII 且無 PUA（如 U+XXXX 十六進位查詢）→ None（維持系統字型）。
+
+    註：單一字型欄位無法逐字混排；真正的逐字渲染在左／中／右面板。
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return None
+    for ch in stripped:
+        if _is_pua(ord(ch)):
+            return ch
+    if all(ord(ch) > 127 for ch in stripped):
+        return stripped[0]
+    return None
+
+
+def glyph_font_runs(text: Optional[str]) -> List[Tuple[str, bool]]:
+    """將文字切成 (子字串, 需逐字解析字型) 的連續段。
+
+    連續 ASCII（<128）併為一段、回 False（用基準系統字型即可）；
+    每個非 ASCII 字各自成段、回 True（需 get_font_for_char 逐字解析，
+    因 CJK／亞美尼亞／PUA 造字／樹狀符號可能各需不同字型，不可併用單一字型）。
+
+    用於中欄結果列表的自訂儲存格逐字繪製；保證各段串接後等於原字串。
+    """
+    runs: List[Tuple[str, bool]] = []
+    ascii_buf: List[str] = []
+    for ch in text or "":
+        if ord(ch) > 127:
+            if ascii_buf:
+                runs.append(("".join(ascii_buf), False))
+                ascii_buf = []
+            runs.append((ch, True))
+        else:
+            ascii_buf.append(ch)
+    if ascii_buf:
+        runs.append(("".join(ascii_buf), False))
+    return runs
+
+
 def _split_top_operands(tokens: List[str]) -> List[List[str]]:
     """將 IDS tokens 按頂層 IDC 切出 operands sub-list。
 

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -165,6 +165,99 @@ def glyph_font_runs(text: Optional[str]) -> List[Tuple[str, bool]]:
     return runs
 
 
+def font_cache_key(
+    char: str, size: float, font_family: Optional[str]
+) -> Tuple[str, float, Optional[str]]:
+    """組 get_font_for_char 的字型快取鍵，把當前文件家族名納入識別。
+
+    last_resort（PUA 造字）的字型解析依「當前開啟 Glyphs 文件的家族名」而定，
+    故同一 (char, size) 在不同文件可能應對到不同字型。鍵不含家族身分時會跨文件
+    誤命中、回傳前一文件的陳舊字型（#19 回歸）。font_family 空字串正規化為 None，
+    使「無開啟文件」狀態有穩定且一致的鍵。
+    """
+    return (char, size, font_family or None)
+
+
+def utf16_len(text: str) -> int:
+    """字串的 UTF-16 碼元長度（補充平面字計 2，BMP 計 1）。
+
+    CoreText 的 CTFontCreateForString range 以 UTF-16 計量，Python len() 以碼位計量；
+    補充平面字（CJK Ext-B、補充平面 PUA）若用 len() 只涵蓋前導代理，故需此換算。
+    """
+    return sum(2 if ord(ch) > 0xFFFF else 1 for ch in text or "")
+
+
+def choose_glyph_font_source(
+    family_covers: bool, covering_found: bool
+) -> Optional[str]:
+    """PUA 缺字字型解析的優先序：回 'family' / 'covering' / None。
+
+    1) 當前文件同名安裝字型確實涵蓋 → 'family'（編輯中優先）；
+    2) 否則有其他已安裝字型涵蓋 → 'covering'；
+    3) 都沒有 → None（退系統字型、由負向快取記住待重試）。
+
+    第 3 步必為 None，不可退回「已確認不涵蓋」的同名字型——否則上層會把它當正向
+    結果快取（sticky 豆腐、forget_missing 清不掉）。見 [[FontCache]] 負向快取設計。
+    """
+    if family_covers:
+        return "family"
+    if covering_found:
+        return "covering"
+    return None
+
+
+class FontCache:
+    """get_font_for_char 的字型快取：正向（鍵→字型）與負向（鍵→已知無涵蓋字型）。
+
+    負向快取是效能關鍵：某 PUA 碼位無任何已安裝字型涵蓋時，若不記住，中欄 cell
+    每次重繪都會重跑全字型暴力掃描造成捲動卡頓。負向項視為暫時性（使用者可能稍後
+    安裝字型），故 forget_missing() 於新搜尋時清掉以重試；正向項（家族已納入鍵、
+    永久有效）保留不動。容量達上限時驅逐前半，負向項一併計入避免無上限成長。
+
+    純資料結構、不依賴 AppKit：字型值為不透明物件，由 UI 層注入。
+    """
+
+    _MISSING = object()  # sentinel：此鍵已知無涵蓋字型
+
+    def __init__(self, max_size: int = 500):
+        self._cache: Dict = {}
+        self._max_size = max_size
+
+    def lookup(self, key) -> Tuple[str, object]:
+        """回 (state, font)：('hit', font) / ('missing', None) / ('miss', None)。"""
+        if key not in self._cache:
+            return ("miss", None)
+        value = self._cache[key]
+        if value is self._MISSING:
+            return ("missing", None)
+        return ("hit", value)
+
+    def store(self, key, font) -> None:
+        self._evict_if_needed()
+        self._cache[key] = font
+
+    def store_missing(self, key) -> None:
+        self._evict_if_needed()
+        self._cache[key] = self._MISSING
+
+    def forget_missing(self) -> None:
+        """清掉所有負向項，讓無涵蓋字型的碼位於下次重新解析（可能已裝新字型）。"""
+        self._cache = {
+            k: v for k, v in self._cache.items() if v is not self._MISSING
+        }
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def _evict_if_needed(self) -> None:
+        if len(self._cache) >= self._max_size:
+            for k in list(self._cache.keys())[: self._max_size // 2]:
+                del self._cache[k]
+
+
 def _split_top_operands(tokens: List[str]) -> List[List[str]]:
     """將 IDS tokens 按頂層 IDC 切出 operands sub-list。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hanzi-ids-component-explorer"
-version = "1.2.1"
+version = "1.2.2"
 description = "Glyphs plugin for exploring Chinese character IDS components"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_choose_glyph_font_source.py
+++ b/tests/test_choose_glyph_font_source.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""choose_glyph_font_source：PUA 缺字字型解析的優先序決策純函式（TDD）。
+
+_resolve_glyph_font 的三段優先序：
+1) 當前文件同名安裝字型「確實涵蓋」此碼位 → 用它（編輯中優先）；
+2) 否則掃所有已安裝字型取涵蓋此碼位者 → 用它（與開哪個檔無關）；
+3) 都沒有 → None（退系統字型、由負向快取記住待重試）。
+
+健檢 #1 相扣修正：原第 3 步誤回「已確認不涵蓋」的同名字型，會被 get_font_for_char
+當正向結果 store()（sticky 豆腐、forget_missing 清不掉）。正確應回 None 走 store_missing。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import choose_glyph_font_source  # noqa: E402
+
+
+class TestChooseGlyphFontSource:
+    """choose_glyph_font_source(family_covers, covering_found) → 'family'|'covering'|None。"""
+
+    def test_family_covers_uses_family(self):
+        assert choose_glyph_font_source(True, False) == "family"
+
+    def test_family_covers_takes_priority_over_covering(self):
+        # 文件同名字型涵蓋時優先，即使另有涵蓋字型
+        assert choose_glyph_font_source(True, True) == "family"
+
+    def test_covering_found_when_family_not_cover(self):
+        assert choose_glyph_font_source(False, True) == "covering"
+
+    def test_none_when_nothing_covers(self):
+        # 回歸核心：都不涵蓋 → None（不可退回不涵蓋的同名字型）
+        assert choose_glyph_font_source(False, False) is None

--- a/tests/test_field_display_char.py
+++ b/tests/test_field_display_char.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""field_display_char：決定搜尋框該以哪個字的字型渲染的純函式（TDD）。
+
+NSSearchField 整欄只能單一字型，故策略為：
+1) 含造字（PUA）→ 用第一個 PUA 字（系統字型必缺、最該優先顯示）；
+2) 否則整段非 ASCII（CJK／亞美尼亞等）→ 用首字；
+3) 含 ASCII（如 U+XXXX 十六進位查詢）且無 PUA → None（維持系統字型）。
+PUA 碼位以 chr(0xXXXX) 明確表達，不放字面不可見字元。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import field_display_char  # noqa: E402
+
+E000 = chr(0xE000)
+E001 = chr(0xE001)
+AYB = chr(0x0531)  # Ա
+PEH = chr(0x054A)  # Պ
+TIWN = chr(0x054F)  # Տ
+
+
+class TestFieldDisplayChar:
+    def test_empty_returns_none(self):
+        assert field_display_char("") is None
+
+    def test_none_returns_none(self):
+        assert field_display_char(None) is None
+
+    def test_whitespace_returns_none(self):
+        assert field_display_char("   ") is None
+
+    def test_ascii_unicode_query_returns_none(self):
+        # 十六進位查詢字串（純 ASCII、無實際造字）→ 不改字型
+        assert field_display_char("U+E000") is None
+
+    def test_bare_hex_returns_none(self):
+        assert field_display_char("E000") is None
+
+    def test_single_ascii_returns_none(self):
+        assert field_display_char("5") is None
+
+    def test_single_pua_char(self):
+        assert field_display_char(E000) == E000
+
+    def test_single_armenian_char(self):
+        assert field_display_char(AYB) == AYB
+
+    def test_multi_nonascii_no_pua_uses_first(self):
+        # 無 PUA、整段非 ASCII → 用首字
+        assert field_display_char(PEH + TIWN) == PEH
+
+    def test_cjk_uses_first(self):
+        assert field_display_char("氵木") == "氵"
+
+    def test_pua_wins_over_leading_ascii(self):
+        # 含實際造字（PUA）→ 即使前面有 ASCII，也用該造字驅動欄位字型
+        assert field_display_char("U+" + E000) == E000
+
+    def test_pua_wins_over_leading_cjk(self):
+        # 含造字 → 優先於前導 CJK（單一字型欄位，造字最該顯示）
+        assert field_display_char("木" + E000) == E000
+
+    def test_returns_first_pua_when_multiple(self):
+        assert field_display_char(E000 + "木" + E001) == E000
+
+    def test_strips_surrounding_whitespace(self):
+        assert field_display_char("  " + AYB + "  ") == AYB

--- a/tests/test_font_cache.py
+++ b/tests/test_font_cache.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""FontCache：get_font_for_char 的字型快取純邏輯（TDD，效能回歸守護）。
+
+背景（健檢 #1）：某 PUA 碼位無任何已安裝字型涵蓋時，_resolve_glyph_font 回 None，
+原 get_font_for_char 在此路徑「不寫快取」直接回系統字型。後果：中欄 cell 每次
+捲動／選取／focus 重繪都重跑 _brute_force_covering_font 全字型暴力掃描 → 卡頓。
+
+修法是「負向快取」：記住此鍵已知無涵蓋字型，重繪時直接命中、不再重掃；負向項
+視為暫時性（使用者可能稍後安裝字型），故 forget_missing 於新搜尋時清掉以重試，
+正向項（家族已納入鍵、永久有效）則保留不動。
+
+font 值在純測試中以不透明 sentinel 表達，不需 AppKit。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import FontCache  # noqa: E402
+
+KEY_A = (chr(0xE000), 13, "FontA")
+KEY_B = (chr(0xE001), 13, "FontA")
+FONT = object()  # 不透明字型物件替身
+
+
+class TestLookupStates:
+    """lookup(key) → (state, font)：'hit' / 'missing'（已知無涵蓋）/ 'miss'（未知）。"""
+
+    def test_unknown_key_is_miss(self):
+        cache = FontCache()
+        assert cache.lookup(KEY_A) == ("miss", None)
+
+    def test_hit_after_store(self):
+        cache = FontCache()
+        cache.store(KEY_A, FONT)
+        assert cache.lookup(KEY_A) == ("hit", FONT)
+
+    def test_missing_after_store_missing(self):
+        # 回歸核心：負向結果必須被記住，否則每次重繪都重跑暴力掃描
+        cache = FontCache()
+        cache.store_missing(KEY_A)
+        assert cache.lookup(KEY_A) == ("missing", None)
+
+    def test_positive_and_negative_coexist(self):
+        cache = FontCache()
+        cache.store(KEY_A, FONT)
+        cache.store_missing(KEY_B)
+        assert cache.lookup(KEY_A) == ("hit", FONT)
+        assert cache.lookup(KEY_B) == ("missing", None)
+
+
+class TestForgetMissing:
+    """forget_missing()：清負向項以重試（裝字型後），保留正向項。"""
+
+    def test_forget_missing_drops_negatives(self):
+        cache = FontCache()
+        cache.store_missing(KEY_A)
+        cache.forget_missing()
+        # 負向項已清 → 變回 miss，下次會重新解析（可能命中新裝字型）
+        assert cache.lookup(KEY_A) == ("miss", None)
+
+    def test_forget_missing_keeps_positives(self):
+        cache = FontCache()
+        cache.store(KEY_A, FONT)
+        cache.store_missing(KEY_B)
+        cache.forget_missing()
+        assert cache.lookup(KEY_A) == ("hit", FONT)
+        assert cache.lookup(KEY_B) == ("miss", None)
+
+
+class TestClear:
+    def test_clear_removes_everything(self):
+        cache = FontCache()
+        cache.store(KEY_A, FONT)
+        cache.store_missing(KEY_B)
+        cache.clear()
+        assert cache.lookup(KEY_A) == ("miss", None)
+        assert cache.lookup(KEY_B) == ("miss", None)
+
+
+class TestEviction:
+    """超過上限時驅逐前半（沿用原 get_font_for_char 的容量管理語意）。"""
+
+    def test_evicts_when_exceeding_max(self):
+        cache = FontCache(max_size=4)
+        for i in range(5):
+            cache.store((chr(0xE000 + i), 13, "F"), object())
+        # 第 5 筆寫入前 len 已達上限 → 驅逐前半（最舊 2 筆）
+        assert cache.lookup((chr(0xE000), 13, "F"))[0] == "miss"
+        # 最新寫入仍在
+        assert cache.lookup((chr(0xE004), 13, "F"))[0] == "hit"
+
+    def test_missing_entries_count_toward_eviction(self):
+        # 負向項也占容量，必須一併納入驅逐，避免無上限成長
+        cache = FontCache(max_size=4)
+        for i in range(5):
+            cache.store_missing((chr(0xF000 + i), 13, "F"))
+        # 最舊負向項被驅逐 → miss；最新負向項仍記得 → missing
+        assert cache.lookup((chr(0xF000), 13, "F"))[0] == "miss"
+        assert cache.lookup((chr(0xF004), 13, "F")) == ("missing", None)

--- a/tests/test_font_cache_key.py
+++ b/tests/test_font_cache_key.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""font_cache_key：字型快取鍵組成的純函式（TDD，回歸守護）。
+
+背景（#19 回歸）：get_font_for_char 對 last_resort（PUA 造字）的解析已改為依
+「當前開啟 Glyphs 文件的家族名」而定，故同一 (char, size) 在不同文件可能應對到
+不同字型。原快取鍵僅 (char, size)，會跨文件誤命中，回傳前一文件的陳舊字型
+（顯示錯字形或缺字框）。此函式把家族識別納入快取鍵，杜絕跨文件碰撞。
+
+PUA 碼位以 chr(0xXXXX) 明確表達，不放字面不可見字元。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import font_cache_key  # noqa: E402
+
+E000 = chr(0xE000)  # PUA 造字（系統字型必缺，解析依當前文件）
+E001 = chr(0xE001)
+
+
+class TestFontCacheKey:
+    """font_cache_key(char, size, font_family) → 可雜湊、含文件身分的快取鍵。"""
+
+    def test_same_inputs_give_equal_keys(self):
+        # 同一文件、同字同大小 → 鍵相等（快取命中，避免重複解析）
+        assert font_cache_key(E000, 13, "FontA") == font_cache_key(E000, 13, "FontA")
+
+    def test_different_family_gives_distinct_keys(self):
+        # 回歸核心：同碼位同大小，但不同文件家族 → 鍵必須不同，
+        # 否則文件 A 解析出的 PUA 字型會在文件 B 被誤命中。
+        assert font_cache_key(E000, 13, "FontA") != font_cache_key(E000, 13, "FontB")
+
+    def test_different_char_gives_distinct_keys(self):
+        assert font_cache_key(E000, 13, "FontA") != font_cache_key(E001, 13, "FontA")
+
+    def test_different_size_gives_distinct_keys(self):
+        assert font_cache_key(E000, 13, "FontA") != font_cache_key(E000, 20, "FontA")
+
+    def test_none_and_empty_family_normalize_equal(self):
+        # 無開啟文件（None）與空家族名應視為同一狀態，產生穩定且相等的鍵
+        assert font_cache_key(E000, 13, None) == font_cache_key(E000, 13, "")
+
+    def test_none_family_distinct_from_named_family(self):
+        # 「無文件」與「有具名文件」是不同狀態，不可碰撞
+        assert font_cache_key(E000, 13, None) != font_cache_key(E000, 13, "FontA")
+
+    def test_key_is_hashable(self):
+        # 必須能當 dict 鍵使用（_font_cache 是 dict）
+        cache = {}
+        cache[font_cache_key(E000, 13, "FontA")] = "sentinel"
+        assert cache[font_cache_key(E000, 13, "FontA")] == "sentinel"
+
+    def test_key_encodes_char_and_size(self):
+        # 鍵需可區分 char 與 size（沿用原本以 char+size 為快取維度的語意）
+        key = font_cache_key(E000, 13, None)
+        assert key != font_cache_key(E000, 14, None)
+        assert key != font_cache_key(E001, 13, None)

--- a/tests/test_glyph_font_runs.py
+++ b/tests/test_glyph_font_runs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""glyph_font_runs：把文字切成 (子字串, 需逐字解析字型) 連續段的純函式（TDD）。
+
+用於中欄結果列表的逐字選字型繪製：連續 ASCII 併段（用基準字型）、
+每個非 ASCII 字各自一段（需 get_font_for_char 逐字解析，因 CJK／亞美尼亞／
+PUA／樹狀符號可能各需不同字型）。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import glyph_font_runs  # noqa: E402
+
+E000 = chr(0xE000)
+
+
+class TestGlyphFontRuns:
+    def test_empty(self):
+        assert glyph_font_runs("") == []
+
+    def test_none(self):
+        assert glyph_font_runs(None) == []
+
+    def test_pure_ascii_is_single_run(self):
+        assert glyph_font_runs("U+E000") == [("U+E000", False)]
+
+    def test_single_cjk(self):
+        assert glyph_font_runs("木") == [("木", True)]
+
+    def test_single_pua(self):
+        assert glyph_font_runs(E000) == [(E000, True)]
+
+    def test_each_nonascii_is_its_own_run(self):
+        # 非 ASCII 不合併（可能各需不同字型）
+        assert glyph_font_runs("木林") == [("木", True), ("林", True)]
+
+    def test_mixed_tree_prefix(self):
+        # "├─ 木A"：兩個樹狀符號各自成段、空白併入 ASCII、木單獨、A 併 ASCII
+        assert glyph_font_runs("├─ 木A") == [
+            ("├", True),
+            ("─", True),
+            (" ", False),
+            ("木", True),
+            ("A", False),
+        ]
+
+    def test_leading_ascii_then_nonascii(self):
+        assert glyph_font_runs("ab木") == [("ab", False), ("木", True)]
+
+    def test_concatenation_roundtrip(self):
+        text = "└─ " + E000 + "Ա xyz"
+        assert "".join(seg for seg, _ in glyph_font_runs(text)) == text

--- a/tests/test_utf16_len.py
+++ b/tests/test_utf16_len.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""utf16_len：字串的 UTF-16 碼元長度純函式（TDD）。
+
+CoreText 的 CTFontCreateForString range 以 UTF-16 計量；Python len() 以碼位計量。
+補充平面字（如 CJK Ext-B、補充平面 PUA U+F0000）在 UTF-16 為代理對（2 碼元），
+若用 len()（=1）只涵蓋前導代理 → last_resort 偵測失準。此函式回正確 UTF-16 長度。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import utf16_len  # noqa: E402
+
+
+class TestUtf16Len:
+    def test_ascii_is_one(self):
+        assert utf16_len("A") == 1
+
+    def test_bmp_cjk_is_one(self):
+        assert utf16_len("漢") == 1
+
+    def test_bmp_pua_is_one(self):
+        assert utf16_len(chr(0xE000)) == 1
+
+    def test_astral_is_two(self):
+        # 補充表意平面 CJK Ext-B
+        assert utf16_len(chr(0x20000)) == 2
+
+    def test_astral_pua_is_two(self):
+        # 補充平面 PUA（Plane 15）
+        assert utf16_len(chr(0xF0000)) == 2
+
+    def test_empty_is_zero(self):
+        assert utf16_len("") == 0
+
+    def test_mixed_sums_codeunits(self):
+        # "A" + BMP "漢" + astral → 1 + 1 + 2
+        assert utf16_len("A漢" + chr(0x20000)) == 4


### PR DESCRIPTION
## 摘要

修正 PUA 造字在外掛各區顯示為缺字框（tofu）的問題。

## 根因

外掛繪字依賴系統字型與 `CTFontCreateForString`；PUA 碼位無 script 關聯，無法靠碼位 fallback，一律回 LastResort → 系統字型 → 缺字框。中欄列表另有單一欄字型限制。

## 變更

**字型解析（治本）**
- 缺字（LastResort）時改用 `_resolve_glyph_font`：① 作用中 Glyphs 檔同名安裝字型（且確認涵蓋該字）→ ② 掃所有已安裝字型取涵蓋該碼位者（原生 font-descriptor 比對 + 記憶命中家族 + 後援逐顆掃描）→ ③ 後援。
- `create_attributed_string` 的 CJK 白名單納入 BMP PUA。

**各區顯示**
- 左欄預覽／詳資、右欄相關字：經上述解析即可顯示。
- 中欄結果列表：改用自訂 `NSTextFieldCell`，以 `glyph_font_runs` 逐字選字型繪製。
- 頂部搜尋框：`field_display_char` 依內容挑欄位字型，造字（PUA）優先。

**測試**
- 抽離純函式並加單元測試：`field_display_char`、`glyph_font_runs`。全套 140 passed。

## 限制／備註

- 第一次解析新造字碼位有一次性延遲（之後記憶命中、瞬間顯示），可後續以背景預熱優化。
- `NSSearchField` 單一字型，無法逐字混排；造字優先已涵蓋實際情境。
- 需重新載入外掛（重啟 Glyphs）生效；中欄自訂儲存格的對齊／選取建議實機確認。

Closes #19