### PR TITLE
feat(#26): 參考字型資料夾＋PUA 明確解析路徑

### DIFF
--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -54,6 +54,7 @@ from hanzi_core import (
     choose_glyph_font_source,
     fonts_folder_snapshot,
     is_font_file_name,
+    is_private_font_name,
     is_pua,
     utf16_len,
 )
@@ -1672,7 +1673,8 @@ class HanziComponentSearchTool:
 
         font 為 None 或組字失敗時清空 tooltip，避免殘留上一字的來源資訊；
         'system' 來源代表無字型涵蓋（缺字框），直說狀態而非洩漏
-        .AppleSystemUIFont 私有名。
+        .AppleSystemUIFont 私有名。cascade 命中隱藏系統字型（.SFNS 等）時
+        同樣以通用名代替、不洩漏私有名。
         """
         label = None
         try:
@@ -1680,8 +1682,11 @@ class HanziComponentSearchTool:
                 if source == "system":
                     label = L("tooltip_font_missing")
                 else:
+                    name = font.familyName() or "?"
+                    if is_private_font_name(name):
+                        name = L("font_source_system")
                     label = L("tooltip_display_font").format(
-                        name=font.familyName() or "?",
+                        name=name,
                         source=L("font_source_" + source),
                     )
         except Exception:
@@ -2065,7 +2070,11 @@ class HanziComponentSearchTool:
                 NSURL.fileURLWithPath_(self._fonts_folder)
             )
         except Exception:
-            pass
+            # 靜默 no-op 會讓「開啟資料夾」點了沒反應且無從診斷（如路徑被
+            # 非目錄檔佔用）；印出 traceback 至 Glyphs 巨集面板
+            import traceback
+
+            print(traceback.format_exc())
 
     def _build_list_attributed_string(self, text, highlighted=False):
         """為中欄結果列表逐字挑字型，組 NSAttributedString。
@@ -2270,11 +2279,18 @@ class HanziComponentSearchTool:
         except Exception:
             pass
         try:
-            # 右欄重設 textStorage 會清掉使用者選取（連動禁用插入鈕）；
-            # 內容相同、只換字型，先存後還原選取範圍
+            # 右欄與左欄同理：textStorage 字型屬性一次性烙入，以自身純文字重放
+            # 即可換上新字型（內容不變、含多部件交集右欄——先前漏放導致交集殘留
+            # 舊字型）。重設 textStorage 會清掉使用者選取（連動禁用插入鈕），先存後還原
             text_view = self.w.relatedChars.getNSTextView()
             selected = text_view.selectedRanges()
-            self.update_related_display()
+            text = str(text_view.textStorage().string())
+            if text:
+                text_view.textStorage().setAttributedString_(
+                    self.create_attributed_string(
+                        text, RELATED_CHARS_FONT_SIZE, use_enhanced_spacing=True
+                    )
+                )
             text_view.setSelectedRanges_(selected)
         except Exception:
             pass

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -33,6 +33,13 @@ from AppKit import (
     NSTableViewNoColumnAutoresizing,
     NSLineBreakByClipping,
     NSTextFieldCell,
+    NSWorkspace,
+)
+from Foundation import (
+    NSURL,
+    NSSearchPathForDirectoriesInDomains,
+    NSApplicationSupportDirectory,
+    NSUserDomainMask,
 )
 import CoreText
 
@@ -45,6 +52,9 @@ from hanzi_core import (
     font_cache_key,
     FontCache,
     choose_glyph_font_source,
+    fonts_folder_snapshot,
+    is_font_file_name,
+    is_pua,
     utf16_len,
 )
 from glyphs_adapter import GlyphsAdapter, GlyphsSettings
@@ -134,6 +144,9 @@ class _FilterMenuHandlerBase(NSObject):
     def selectCustomCharset_(self, sender):
         self.tool.selectCustomCharset()
 
+    def openReferenceFontsFolder_(self, sender):
+        self.tool.open_reference_fonts_folder()
+
 
 # 使用動態名稱避免重複定義
 FilterMenuHandler = type(filter_handler_class_name, (_FilterMenuHandlerBase,), {})
@@ -213,6 +226,12 @@ class HanziComponentSearchTool:
         self._search_field_font_char = None
         # 已命中、能涵蓋造字的字型家族名（加速後續同類造字、消除掃描延遲）
         self._covering_font_families = []
+
+        # 參考字型資料夾（#26）：快照供變動偵測、字型 lazy 載入供 PUA 最優先解析
+        self._fonts_folder = self._resolve_fonts_folder_path()
+        self._fonts_folder_snapshot = ()
+        self._folder_fonts = None  # None＝待載入；載入後為 [(descriptor, charset), ...]
+        self._rescan_fonts_folder()
 
         # 模式切換：自動模式 vs 手動模式
         # 自動模式：選擇字符時清空搜尋框，使用多 Unicode 智能偵測
@@ -511,6 +530,25 @@ class HanziComponentSearchTool:
         custom_item.setTarget_(self.filterMenuHandler)
         custom_item.setState_(NSOnState if self.use_custom_charset else NSOffState)
         menu.addItem_(custom_item)
+
+        # 參考字型資料夾（#26）：資訊列（無 action 自動禁用）＋開啟入口
+        menu.addItem_(NSMenuItem.separatorItem())
+        self._rescan_fonts_folder()
+        count = len(self._fonts_folder_snapshot)
+        if count > 0:
+            info_title = L("menu_ref_fonts_count").format(count=count)
+        else:
+            info_title = L("menu_ref_fonts_empty")
+        info_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            info_title, None, ""
+        )
+        menu.addItem_(info_item)
+
+        open_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            L("menu_open_ref_fonts_folder"), "openReferenceFontsFolder:", ""
+        )
+        open_item.setTarget_(self.filterMenuHandler)
+        menu.addItem_(open_item)
 
         # 在按鈕下方顯示選單
         button = sender.getNSButton()
@@ -831,8 +869,10 @@ class HanziComponentSearchTool:
         自動模式：使用 self.current_char（已由 on_glyph_changed 設定）
         手動模式：使用搜尋框內容
         """
-        # 新搜尋時清掉負向字型快取：若使用者期間安裝了含某 PUA 的字型，
+        # 新搜尋時：先偵測參考字型資料夾變動（有變即由 rescan 失效並重繪，#26），
+        # 再清負向快取——若使用者期間安裝了含某 PUA 的字型，
         # 讓該碼位重新解析以正確顯示（正向快取保留，不影響效能）。
+        self._rescan_fonts_folder()
         self._font_cache.forget_missing()
 
         input_text = self.w.inputText.get().strip()
@@ -1577,8 +1617,9 @@ class HanziComponentSearchTool:
     # === 預覽功能 ===
 
     def update_preview(self, char):
-        """更新字符預覽（水平垂直居中）"""
-        font = self.get_font_for_char(char)
+        """更新字符預覽（水平垂直居中），tooltip 顯示解析到的字型與來源"""
+        font, source = self.font_and_source_for_char(char)
+        self._set_preview_tooltip(font, source)
 
         # 垂直偏移量：負值向下移動，正值向上移動
         # 微調讓文字在 90px 高度區域內視覺居中
@@ -1600,84 +1641,83 @@ class HanziComponentSearchTool:
         )
         self.w.preview.set(preview_text)
 
+    def _set_preview_tooltip(self, font, source):
+        """預覽區 tooltip 顯示「顯示字型：名稱（來源）」，讓字型選擇可觀察（#26）。"""
+        try:
+            name = font.familyName() if font is not None else None
+            label = L("tooltip_display_font").format(
+                name=name or "?", source=L("font_source_" + source)
+            )
+            self.w.preview.getNSTextField().setToolTip_(label)
+        except Exception:
+            pass
+
     def get_font_for_char(self, char, size=72):
-        """
-        使用 macOS 原生 CTFontCreateForString 自動選擇字型
+        """回能顯示該字符的 NSFont（font_and_source_for_char 的字型部分）。"""
+        return self.font_and_source_for_char(char, size)[0]
 
-        讓系統自動從 cascade list 尋找能顯示該字符的字型，
-        無需硬編碼特定字型家族，支援不同區域使用者的系統字型。
+    def font_and_source_for_char(self, char, size=72):
+        """解析字型並附來源：(NSFont, 'folder'|'family'|'covering'|'cascade'|'system')。
 
-        參數:
-            char: 要顯示的字符
-            size: 字型大小（預設 72pt）
-
-        回傳:
-            NSFont: 能顯示該字符的字型
+        PUA 碼位不信任系統 cascade——任何字型對 PUA 的涵蓋都是各自為政，
+        cascade 會回「第一個涵蓋的已安裝字型」（#26：DIN 搶走造字顯示），
+        故直接走 _resolve_glyph_font 的明確優先序（資料夾→文件同名→已安裝掃描）。
+        其餘字元維持 CTFontCreateForString 自動選擇，無需硬編碼字型家族。
+        來源標記供預覽 tooltip 顯示「為什麼是這套字型」。
         """
         if not char:
-            return NSFont.systemFontOfSize_(size)
+            return (NSFont.systemFontOfSize_(size), "system")
 
-        # 查詢快取（鍵納入當前文件家族名：last_resort/PUA 解析依當前文件而定，
+        # 查詢快取（鍵納入當前文件家族名：PUA 解析依當前文件而定，
         # 否則切換文件時同碼位會誤命中前一文件的陳舊字型，見 #19 回歸）
         cache_key = font_cache_key(char, size, self._current_font_family())
         state, cached = self._font_cache.lookup(cache_key)
         if state == "hit":
             return cached
         if state == "missing":
-            # 已知系統無任何字型涵蓋此碼位 → 直接回系統字型，
+            # 已知無任何字型涵蓋此碼位 → 直接回系統字型，
             # 不再重跑全字型暴力掃描（負向快取，消除重繪卡頓，見健檢 #1）
-            return NSFont.systemFontOfSize_(size)
+            return (NSFont.systemFontOfSize_(size), "system")
 
         try:
-            # 建立基礎 CTFont（系統 UI 字型包含完整的 cascade list）
-            base_ct_font = CoreText.CTFontCreateWithName(
-                ".AppleSystemUIFont", size, None
-            )
-
-            # 使用 CTFontCreateForString 尋找能顯示該字符的字型
-            # range 以 UTF-16 計量：補充平面字（如補充平面 PUA）需 utf16_len，
-            # 用 Python len() 只會涵蓋前導代理 → last_resort 偵測失準
-            fallback_ct_font = CoreText.CTFontCreateForString(
-                base_ct_font, char, (0, utf16_len(char))
-            )
-
-            # 釋放 base_ct_font（不再需要，避免記憶體洩漏）
-            del base_ct_font
-
-            # 取得 fallback 字型的 PostScript 名稱
-            ps_name = CoreText.CTFontCopyPostScriptName(fallback_ct_font)
-
-            # 檢查是否為 LastResort 字型（表示系統找不到適合的字型）
-            is_last_resort = ps_name and "LastResort" in str(ps_name)
-
-            # 釋放 ps_name（不再需要）
-            del ps_name
-
-            if is_last_resort:
-                # 釋放 fallback_ct_font（不使用）
-                del fallback_ct_font
-                # PUA 造字等「系統 cascade 無法靠碼位 fallback」的字（如以 IDS 組出的
-                # U+E000）：先試開啟檔的同名字型，再掃所有已安裝字型找涵蓋此碼位者
-                # （只要系統裝了含該字的字型就顯示得出，不必是當前開啟的檔）。
-                installed = self._resolve_glyph_font(char, size)
-                if installed is None:
-                    # 系統無任何字型含此碼位 → 退系統字型（顯示為缺字框）並記住此鍵，
-                    # 避免每次重繪重跑暴力掃描；使用者安裝字型後由下次搜尋
-                    # forget_missing() 清掉負向項重試（見健檢 #1）。
-                    self._font_cache.store_missing(cache_key)
-                    return NSFont.systemFontOfSize_(size)
-                font = installed
+            if is_pua(ord(char[0])):
+                resolved = self._resolve_glyph_font(char, size)
             else:
-                # CTFont 和 NSFont 可透過 toll-free bridging 互轉
-                font = fallback_ct_font
+                resolved = self._cascade_font(char, size)
+                if resolved is None:
+                    # cascade 回 LastResort（如 CDP 區、罕見符號）→ 同走明確解析
+                    resolved = self._resolve_glyph_font(char, size)
 
-            # 快取結果（容量管理由 FontCache 內部處理）
-            self._font_cache.store(cache_key, font)
-            return font
+            if resolved is None:
+                # 無任何字型含此碼位 → 退系統字型（顯示為缺字框）並記住此鍵；
+                # 使用者安裝字型或更新參考資料夾後，由下次搜尋清掉負向項重試。
+                self._font_cache.store_missing(cache_key)
+                return (NSFont.systemFontOfSize_(size), "system")
+
+            # 快取 (font, source)（容量管理由 FontCache 內部處理）
+            self._font_cache.store(cache_key, resolved)
+            return resolved
 
         except Exception:
             # 發生錯誤時 fallback 到系統字型
-            return NSFont.systemFontOfSize_(size)
+            return (NSFont.systemFontOfSize_(size), "system")
+
+    def _cascade_font(self, char, size):
+        """CTFontCreateForString 走系統 cascade；LastResort 回 None。
+
+        range 以 UTF-16 計量：補充平面字需 utf16_len，用 Python len()
+        只會涵蓋前導代理 → LastResort 偵測失準。
+        """
+        # 基礎 CTFont 用系統 UI 字型（包含完整 cascade list）
+        base_ct_font = CoreText.CTFontCreateWithName(".AppleSystemUIFont", size, None)
+        fallback_ct_font = CoreText.CTFontCreateForString(
+            base_ct_font, char, (0, utf16_len(char))
+        )
+        ps_name = CoreText.CTFontCopyPostScriptName(fallback_ct_font)
+        if ps_name and "LastResort" in str(ps_name):
+            return None
+        # CTFont 和 NSFont 可透過 toll-free bridging 互轉
+        return (fallback_ct_font, "cascade")
 
     def _current_font_family(self):
         """目前開啟 Glyphs 文件的家族名；無文件、無名稱或取值失敗皆回 None。
@@ -1801,32 +1841,152 @@ class HanziComponentSearchTool:
         return None
 
     def _resolve_glyph_font(self, char, size):
-        """為缺字（LastResort）的字解析能顯示它的已安裝字型，找不到回 None。
+        """為 PUA／缺字解析字型，回 (font, source)，找不到回 None。
 
         順序（優先序判定見 hanzi_core.choose_glyph_font_source）：
-        1) 目前開啟的 Glyphs 檔同名安裝字型，且確認真的涵蓋此字 → 直接用（編輯中優先）
-        2) 掃所有已安裝字型取涵蓋此碼位者（與開哪個檔無關 → 安裝了就能顯示）
-        3) 都不涵蓋 → None（退系統字型、由負向快取記住待重試）。
+        1) 參考字型資料夾內涵蓋此碼位的字型 → 用它（使用者明確意圖，#26）
+        2) 目前開啟的 Glyphs 檔同名安裝字型，且確認真的涵蓋此字 → 用它（編輯中優先）
+        3) 掃所有已安裝字型取涵蓋此碼位者（與開哪個檔無關 → 安裝了就能顯示）
+        4) 都不涵蓋 → None（退系統字型、由負向快取記住待重試）。
            不退回不涵蓋的同名字型，否則只是另一種豆腐且會被當正向結果快取。
         """
         code_point = ord(char[0]) if char else None
         if code_point is None:
             return None
 
-        family_font = self._resolve_installed_font(size)
-        family_covers = family_font is not None and self._font_covers(
-            family_font, code_point
-        )
-        covering = (
-            None if family_covers else self._font_covering_codepoint(code_point, size)
-        )
+        folder_font = self._folder_font_covering(code_point, size)
 
-        choice = choose_glyph_font_source(family_covers, covering is not None)
+        family_font = None
+        family_covers = False
+        if folder_font is None:
+            family_font = self._resolve_installed_font(size)
+            family_covers = family_font is not None and self._font_covers(
+                family_font, code_point
+            )
+
+        covering = None
+        if folder_font is None and not family_covers:
+            covering = self._font_covering_codepoint(code_point, size)
+
+        choice = choose_glyph_font_source(
+            folder_font is not None, family_covers, covering is not None
+        )
+        if choice == "folder":
+            return (folder_font, "folder")
         if choice == "family":
-            return family_font
+            return (family_font, "family")
         if choice == "covering":
-            return covering
+            return (covering, "covering")
         return None
+
+    # === 參考字型資料夾（#26）===
+
+    def _resolve_fonts_folder_path(self):
+        """參考字型資料夾路徑；位於 Application Support 下，不隨外掛更新被清掉。
+
+        程序生命週期不變，__init__ 算一次存 self._fonts_folder。
+        """
+        try:
+            base = NSSearchPathForDirectoriesInDomains(
+                NSApplicationSupportDirectory, NSUserDomainMask, True
+            )[0]
+        except Exception:
+            return None
+        return os.path.join(base, "Glyphs 3", "HanziIDSComponentExplorer", "Fonts")
+
+    def _rescan_fonts_folder(self):
+        """比對資料夾快照，有變動即失效字型解析衍生狀態並重繪；回傳是否有變動。
+
+        熱更新機制：掛在視窗 became key、每次搜尋、開選單三個時點。使用者
+        重新匯出字型後切回視窗即生效，無需手動重掃、無需刪除重裝安裝版。
+        """
+        entries = []
+        if self._fonts_folder and os.path.isdir(self._fonts_folder):
+            try:
+                for entry in os.scandir(self._fonts_folder):
+                    # 先按檔名過濾再 stat，略過 .DS_Store 等非字型檔的 syscall
+                    if is_font_file_name(entry.name) and entry.is_file():
+                        entries.append((entry.name, entry.stat().st_mtime))
+            except OSError:
+                pass
+        snapshot = fonts_folder_snapshot(entries)
+        if snapshot == self._fonts_folder_snapshot:
+            return False
+        self._fonts_folder_snapshot = snapshot
+        # 資料夾變動會改變解析結果：字型 lazy 重載、快取全清（正向項可能指向
+        # 舊資料夾字型、負向項的碼位可能已被新字型涵蓋）、搜尋框字型 memo 失效，
+        # 然後重繪依字型解析的顯示區——失效與重繪集中於此，呼叫端無需串接
+        self._folder_fonts = None
+        self._font_cache.clear()
+        self._search_field_font_char = None
+        self._refresh_font_dependent_views()
+        return True
+
+    def _load_folder_fonts(self):
+        """從資料夾檔案載入 (descriptor, charset) 對，charset 於載入時預取一次。
+
+        以 CTFontManagerCreateFontDescriptorsFromURL 直接讀檔、不註冊進系統：
+        與同名已安裝字型不衝突（開發中不必先移除舊版），且每次資料夾變動
+        都重新讀檔，不受 macOS 字型快取影響。charset 與 size 無關，預取後
+        涵蓋判定不必逐次建字型。
+        """
+        fonts = []
+        for name, _mtime in self._fonts_folder_snapshot:
+            try:
+                url = NSURL.fileURLWithPath_(
+                    os.path.join(self._fonts_folder, name)
+                )
+                descriptors = (
+                    CoreText.CTFontManagerCreateFontDescriptorsFromURL(url) or []
+                )
+                for descriptor in descriptors:
+                    font = CoreText.CTFontCreateWithFontDescriptor(
+                        descriptor, 12, None
+                    )
+                    charset = (
+                        CoreText.CTFontCopyCharacterSet(font)
+                        if font is not None
+                        else None
+                    )
+                    if charset is not None:
+                        fonts.append((descriptor, charset))
+            except Exception:
+                continue
+        return fonts
+
+    def _folder_font_covering(self, code_point, size):
+        """回參考資料夾中第一個涵蓋該碼位的字型；資料夾空或都不涵蓋回 None。
+
+        涵蓋判定走預取的 charset，只對命中的 descriptor 以目標尺寸實體化，
+        避免 cache-miss 熱路徑上逐 descriptor 建字型。首次呼叫才載入（lazy），
+        外掛啟動不被字型檔 I/O 阻塞。
+        """
+        if self._folder_fonts is None:
+            self._folder_fonts = self._load_folder_fonts()
+        for descriptor, charset in self._folder_fonts:
+            try:
+                if not charset.longCharacterIsMember_(code_point):
+                    continue
+                font = CoreText.CTFontCreateWithFontDescriptor(
+                    descriptor, size, None
+                )
+            except Exception:
+                continue
+            if font is not None:
+                return font
+        return None
+
+    def open_reference_fonts_folder(self):
+        """建立（若不存在）並在 Finder 開啟參考字型資料夾（篩選選單入口）。"""
+        if not self._fonts_folder:
+            return
+        try:
+            os.makedirs(self._fonts_folder, exist_ok=True)
+            NSWorkspace.sharedWorkspace().openURL_(
+                NSURL.fileURLWithPath_(self._fonts_folder)
+            )
+        except Exception:
+            pass
 
     def _build_list_attributed_string(self, text, highlighted=False):
         """為中欄結果列表逐字挑字型，組 NSAttributedString。
@@ -1993,9 +2153,25 @@ class HanziComponentSearchTool:
         """
         視窗獲得焦點時的回調（Issue #31）
 
-        進入手動模式，暫停自動跟隨 Glyphs 選中字符
+        進入手動模式，暫停自動跟隨 Glyphs 選中字符。
+        同時偵測參考字型資料夾變動（#26）：重新匯出字型後切回視窗即重新解析。
         """
         self.is_manual_mode = True
+        self._rescan_fonts_folder()
+
+    def _refresh_font_dependent_views(self):
+        """字型快取失效後重繪依字型解析的顯示區（搜尋框、預覽、中欄列表、右欄相關字）。"""
+        if getattr(self, "w", None) is None:
+            return  # __init__ 首次掃描時視窗尚未建立
+        try:
+            self._update_search_field_font()
+            char = self._right_panel_char or self.current_char
+            if char:
+                self.update_preview(char)
+                self.update_related_display()
+            self.w.resultList.getNSTableView().setNeedsDisplay_(True)
+        except Exception:
+            pass
 
     def on_window_resigned_key(self, sender):
         """

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -581,8 +581,8 @@ class HanziComponentSearchTool:
         self.use_custom_charset = False
         self.settings.remove("customCharsetPath")  # 清除儲存的自訂字集路徑
         self.loadFontCharset()
-        # 更新相關顯示
-        self.update_related_display()
+        # 更新相關顯示（多部件模式重繪交集——字集變動影響交集內容）
+        self._refresh_related_column()
 
     def selectCustomCharset(self):
         """選擇自訂字集檔案"""
@@ -601,8 +601,8 @@ class HanziComponentSearchTool:
             # 保存設定
             self.settings.set("customCharsetPath", path)
 
-            # 更新相關顯示
-            self.update_related_display()
+            # 更新相關顯示（多部件模式重繪交集——字集變動影響交集內容）
+            self._refresh_related_column()
 
     def loadCustomCharset(self, path):
         """載入自訂字集檔案"""
@@ -1537,6 +1537,19 @@ class HanziComponentSearchTool:
         except Exception:
             pass
 
+    def _refresh_related_column(self):
+        """右欄「依當前狀態重繪」的單一入口：字集切換與筆畫篩選等內容變動共用。
+
+        多部件模式重算 AND 交集（_render_intersection 依 currentCharset／筆畫
+        重算、無單一焦點字，裸 update_related_display 會因無焦點字而 no-op）；
+        否則重算 sticky/current 焦點字的相關字。集中一處避免各 callback 手抄
+        mode 分派而漂移。字型熱更新不經此處——內容不變、走 textStorage 重放。
+        """
+        if self.multi_component_mode:
+            self._render_intersection(self.multi_component_parts)
+        else:
+            self.update_related_display()
+
     def on_stroke_filter_changed(self, sender):
         """筆畫篩選滑桿 callback：四捨五入到最近的 tick"""
         new_tick = int(round(sender.get()))
@@ -1548,10 +1561,7 @@ class HanziComponentSearchTool:
         self.stroke_filter_tick = new_tick
         self.settings.set("strokeFilterTick", new_tick)
         self._refresh_stroke_filter_display()
-        if self.multi_component_mode:
-            self._render_intersection(self.multi_component_parts)
-        else:
-            self.update_related_display()
+        self._refresh_related_column()
 
     def _apply_chars_filters(self, chars, display_char, related_chars, stroke_max_diff):
         """套用 related_chars 排除 + 顏色 + 筆畫 三道篩選、回篩後 list（保持原順序）。"""

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -189,10 +189,17 @@ SelectionObserverHandler = type(
 class HanziComponentSearchTool:
     """Glyphs 外掛主視窗"""
 
-    # 字型快取（類別層級）：正向（鍵→NSFont）＋負向（已知無涵蓋字型）
+    # 字型快取（類別層級）：正向（鍵→(NSFont, source)）＋負向（已知無涵蓋字型）
     # 鍵為 font_cache_key(char, size, font_family)
     _CACHE_MAX_SIZE = 500  # 最大快取數量
     _font_cache = FontCache(_CACHE_MAX_SIZE)
+
+    # 參考字型資料夾狀態（#26）：與 _font_cache 同為類別層級——快取的失效
+    # 基準必須與快取同壽命，否則重開視窗會誤判變動（清掉跨實例快取）或
+    # 漏判「關窗期間資料夾被清空」（沿用已刪字型）。寫入一律走 type(self)。
+    _fonts_folder_snapshot = ()
+    _folder_fonts = None  # None＝待載入；載入後為 [(descriptor, charset), ...]
+    _folder_load_failures = 0  # 上次載入時無法產出任何字型的檔案數（供資訊列）
 
     def __init__(self, title=None):
         # === 初始化核心引擎 ===
@@ -227,10 +234,12 @@ class HanziComponentSearchTool:
         # 已命中、能涵蓋造字的字型家族名（加速後續同類造字、消除掃描延遲）
         self._covering_font_families = []
 
-        # 參考字型資料夾（#26）：快照供變動偵測、字型 lazy 載入供 PUA 最優先解析
+        # 參考字型資料夾（#26）：路徑跨實例恆定存實例即可；快照與字型為
+        # 類別屬性（見類別定義處）。init 掃描與既存類別快照比對——重開視窗
+        # 且資料夾未變時不清快取、關窗期間的變動（含清空）也偵測得到
         self._fonts_folder = self._resolve_fonts_folder_path()
-        self._fonts_folder_snapshot = ()
-        self._folder_fonts = None  # None＝待載入；載入後為 [(descriptor, charset), ...]
+        # 預覽區當前顯示的字（update_preview 記錄、熱更新重繪時重播）
+        self._preview_char = None
         self._rescan_fonts_folder()
 
         # 模式切換：自動模式 vs 手動模式
@@ -534,8 +543,16 @@ class HanziComponentSearchTool:
         # 參考字型資料夾（#26）：資訊列（無 action 自動禁用）＋開啟入口
         menu.addItem_(NSMenuItem.separatorItem())
         self._rescan_fonts_folder()
-        count = len(self._fonts_folder_snapshot)
-        if count > 0:
+        cls = type(self)
+        count = len(cls._fonts_folder_snapshot)
+        # 載入失敗數只在已實際載入後可知（lazy）；有失敗就標示，
+        # 避免資訊列替損壞檔背書「有讀到」
+        failures = cls._folder_load_failures if cls._folder_fonts is not None else 0
+        if count > 0 and failures > 0:
+            info_title = L("menu_ref_fonts_count_failed").format(
+                count=count, failed=failures
+            )
+        elif count > 0:
             info_title = L("menu_ref_fonts_count").format(count=count)
         else:
             info_title = L("menu_ref_fonts_empty")
@@ -869,11 +886,12 @@ class HanziComponentSearchTool:
         自動模式：使用 self.current_char（已由 on_glyph_changed 設定）
         手動模式：使用搜尋框內容
         """
-        # 新搜尋時：先偵測參考字型資料夾變動（有變即由 rescan 失效並重繪，#26），
-        # 再清負向快取——若使用者期間安裝了含某 PUA 的字型，
-        # 讓該碼位重新解析以正確顯示（正向快取保留，不影響效能）。
-        self._rescan_fonts_folder()
+        # 新搜尋時：先清負向快取（讓期間安裝的字型重試；forget_missing 不動
+        # 正向項），再偵測參考字型資料夾變動（有變即由 rescan 集中失效並重繪，
+        # #26）。順序不可反——rescan 內建重繪會對無涵蓋碼位寫入負向項，
+        # 隨後才 forget_missing 的話同一輪搜尋會重跑兩次全字型掃描。
         self._font_cache.forget_missing()
+        self._rescan_fonts_folder()
 
         input_text = self.w.inputText.get().strip()
 
@@ -1056,6 +1074,9 @@ class HanziComponentSearchTool:
         """清空左欄（預覽 + 詳資）；多部件模式無單一焦點字時使用。"""
         self.current_char = None
         self._right_panel_char = None
+        # 預覽已空：清掉重播記錄與 tooltip，避免熱更新把 stale 字畫回空白預覽
+        self._preview_char = None
+        self._set_preview_tooltip(None, None)
         self.w.preview.set("")
         self.w.content.set("")
         self.w.idsSwitcher.show(False)
@@ -1617,7 +1638,12 @@ class HanziComponentSearchTool:
     # === 預覽功能 ===
 
     def update_preview(self, char):
-        """更新字符預覽（水平垂直居中），tooltip 顯示解析到的字型與來源"""
+        """更新字符預覽（水平垂直居中），tooltip 顯示解析到的字型與來源。
+
+        記下當前顯示字供熱更新重播——預覽不跟隨右欄 sticky，重繪時
+        不可用 _right_panel_char 重新推導（會產生換字副作用）。
+        """
+        self._preview_char = char
         font, source = self.font_and_source_for_char(char)
         self._set_preview_tooltip(font, source)
 
@@ -1642,12 +1668,25 @@ class HanziComponentSearchTool:
         self.w.preview.set(preview_text)
 
     def _set_preview_tooltip(self, font, source):
-        """預覽區 tooltip 顯示「顯示字型：名稱（來源）」，讓字型選擇可觀察（#26）。"""
+        """預覽區 tooltip 顯示「顯示字型：名稱（來源）」，讓字型選擇可觀察（#26）。
+
+        font 為 None 或組字失敗時清空 tooltip，避免殘留上一字的來源資訊；
+        'system' 來源代表無字型涵蓋（缺字框），直說狀態而非洩漏
+        .AppleSystemUIFont 私有名。
+        """
+        label = None
         try:
-            name = font.familyName() if font is not None else None
-            label = L("tooltip_display_font").format(
-                name=name or "?", source=L("font_source_" + source)
-            )
+            if font is not None:
+                if source == "system":
+                    label = L("tooltip_font_missing")
+                else:
+                    label = L("tooltip_display_font").format(
+                        name=font.familyName() or "?",
+                        source=L("font_source_" + source),
+                    )
+        except Exception:
+            label = None
+        try:
             self.w.preview.getNSTextField().setToolTip_(label)
         except Exception:
             pass
@@ -1661,9 +1700,13 @@ class HanziComponentSearchTool:
 
         PUA 碼位不信任系統 cascade——任何字型對 PUA 的涵蓋都是各自為政，
         cascade 會回「第一個涵蓋的已安裝字型」（#26：DIN 搶走造字顯示），
-        故直接走 _resolve_glyph_font 的明確優先序（資料夾→文件同名→已安裝掃描）。
+        故先走 _resolve_glyph_font 的明確優先序（資料夾→文件同名→已安裝掃描），
+        三層全滅才以 cascade 收尾（隱藏系統字型如 .SFNS 只有 cascade 找得到；
+        可見字型已在掃描層被攔，不會回到 cascade 任選的 #26 問題）。
         其餘字元維持 CTFontCreateForString 自動選擇，無需硬編碼字型家族。
         來源標記供預覽 tooltip 顯示「為什麼是這套字型」。
+        char 預期為單一字元（上游 glyph_font_runs／field_display_char 已逐字
+        切分）；多字字串僅以首碼位分流。
         """
         if not char:
             return (NSFont.systemFontOfSize_(size), "system")
@@ -1682,6 +1725,8 @@ class HanziComponentSearchTool:
         try:
             if is_pua(ord(char[0])):
                 resolved = self._resolve_glyph_font(char, size)
+                if resolved is None:
+                    resolved = self._cascade_font(char, size)
             else:
                 resolved = self._cascade_font(char, size)
                 if resolved is None:
@@ -1758,13 +1803,26 @@ class HanziComponentSearchTool:
         except Exception:
             return None
 
+    @staticmethod
+    def _charset_covers(charset, code_point):
+        """charset 是否涵蓋該碼位（支援補充平面）；None 視為不涵蓋。
+
+        涵蓋語意的唯一謂詞——_font_covers 與 _folder_font_covering 共用，
+        避免 folder 與 installed 兩個 tier 對同一碼位給出不同結論。
+        """
+        try:
+            return charset is not None and bool(
+                charset.longCharacterIsMember_(code_point)
+            )
+        except Exception:
+            return False
+
     def _font_covers(self, ns_font, code_point):
         """以字型的 character set 判定是否涵蓋該碼位（支援補充平面）。"""
         try:
-            char_set = CoreText.CTFontCopyCharacterSet(ns_font)
-            if char_set is None:
-                return False
-            return bool(char_set.longCharacterIsMember_(code_point))
+            return self._charset_covers(
+                CoreText.CTFontCopyCharacterSet(ns_font), code_point
+            )
         except Exception:
             return False
 
@@ -1871,13 +1929,14 @@ class HanziComponentSearchTool:
         choice = choose_glyph_font_source(
             folder_font is not None, family_covers, covering is not None
         )
-        if choice == "folder":
-            return (folder_font, "folder")
-        if choice == "family":
-            return (family_font, "family")
-        if choice == "covering":
-            return (covering, "covering")
-        return None
+        if choice is None:
+            return None
+        candidates = {
+            "folder": folder_font,
+            "family": family_font,
+            "covering": covering,
+        }
+        return (candidates[choice], choice)
 
     # === 參考字型資料夾（#26）===
 
@@ -1895,32 +1954,43 @@ class HanziComponentSearchTool:
         return os.path.join(base, "Glyphs 3", "HanziIDSComponentExplorer", "Fonts")
 
     def _rescan_fonts_folder(self):
-        """比對資料夾快照，有變動即失效字型解析衍生狀態並重繪；回傳是否有變動。
+        """比對資料夾快照，有變動即失效字型解析衍生狀態並重繪。
 
         熱更新機制：掛在視窗 became key、每次搜尋、開選單三個時點。使用者
         重新匯出字型後切回視窗即生效，無需手動重掃、無需刪除重裝安裝版。
+        快照為類別層級——與 _font_cache 同壽命，重開視窗不誤判變動，
+        關窗期間的資料夾變動（含清空）也偵測得到。
         """
+        cls = type(self)
         entries = []
         if self._fonts_folder and os.path.isdir(self._fonts_folder):
             try:
-                for entry in os.scandir(self._fonts_folder):
-                    # 先按檔名過濾再 stat，略過 .DS_Store 等非字型檔的 syscall
-                    if is_font_file_name(entry.name) and entry.is_file():
-                        entries.append((entry.name, entry.stat().st_mtime))
+                with os.scandir(self._fonts_folder) as it:
+                    for entry in it:
+                        # 先按檔名過濾再 stat，略過 .DS_Store 等非字型檔的 syscall
+                        if not is_font_file_name(entry.name):
+                            continue
+                        try:
+                            if entry.is_file():
+                                st = entry.stat()
+                                entries.append(
+                                    (entry.name, (st.st_mtime_ns, st.st_size))
+                                )
+                        except OSError:
+                            continue  # scandir 與 stat 之間檔案消失：略過該檔
             except OSError:
-                pass
+                return  # 目錄整體不可讀：保留前一快照，不以殘缺列舉誤判變動
         snapshot = fonts_folder_snapshot(entries)
-        if snapshot == self._fonts_folder_snapshot:
-            return False
-        self._fonts_folder_snapshot = snapshot
+        if snapshot == cls._fonts_folder_snapshot:
+            return
+        cls._fonts_folder_snapshot = snapshot
         # 資料夾變動會改變解析結果：字型 lazy 重載、快取全清（正向項可能指向
         # 舊資料夾字型、負向項的碼位可能已被新字型涵蓋）、搜尋框字型 memo 失效，
         # 然後重繪依字型解析的顯示區——失效與重繪集中於此，呼叫端無需串接
-        self._folder_fonts = None
+        cls._folder_fonts = None
         self._font_cache.clear()
         self._search_field_font_char = None
         self._refresh_font_dependent_views()
-        return True
 
     def _load_folder_fonts(self):
         """從資料夾檔案載入 (descriptor, charset) 對，charset 於載入時預取一次。
@@ -1928,10 +1998,14 @@ class HanziComponentSearchTool:
         以 CTFontManagerCreateFontDescriptorsFromURL 直接讀檔、不註冊進系統：
         與同名已安裝字型不衝突（開發中不必先移除舊版），且每次資料夾變動
         都重新讀檔，不受 macOS 字型快取影響。charset 與 size 無關，預取後
-        涵蓋判定不必逐次建字型。
+        涵蓋判定不必逐次建字型。無法產出任何字型的檔案計入
+        _folder_load_failures 供選單資訊列顯示（損壞檔不再靜默消失）。
         """
+        cls = type(self)
         fonts = []
-        for name, _mtime in self._fonts_folder_snapshot:
+        failures = 0
+        for name, _meta in cls._fonts_folder_snapshot:
+            loaded_any = False
             try:
                 url = NSURL.fileURLWithPath_(
                     os.path.join(self._fonts_folder, name)
@@ -1950,8 +2024,12 @@ class HanziComponentSearchTool:
                     )
                     if charset is not None:
                         fonts.append((descriptor, charset))
+                        loaded_any = True
             except Exception:
-                continue
+                pass
+            if not loaded_any:
+                failures += 1
+        cls._folder_load_failures = failures
         return fonts
 
     def _folder_font_covering(self, code_point, size):
@@ -1961,12 +2039,13 @@ class HanziComponentSearchTool:
         避免 cache-miss 熱路徑上逐 descriptor 建字型。首次呼叫才載入（lazy），
         外掛啟動不被字型檔 I/O 阻塞。
         """
-        if self._folder_fonts is None:
-            self._folder_fonts = self._load_folder_fonts()
-        for descriptor, charset in self._folder_fonts:
+        cls = type(self)
+        if cls._folder_fonts is None:
+            cls._folder_fonts = self._load_folder_fonts()
+        for descriptor, charset in cls._folder_fonts:
+            if not self._charset_covers(charset, code_point):
+                continue
             try:
-                if not charset.longCharacterIsMember_(code_point):
-                    continue
                 font = CoreText.CTFontCreateWithFontDescriptor(
                     descriptor, size, None
                 )
@@ -2160,15 +2239,46 @@ class HanziComponentSearchTool:
         self._rescan_fonts_folder()
 
     def _refresh_font_dependent_views(self):
-        """字型快取失效後重繪依字型解析的顯示區（搜尋框、預覽、中欄列表、右欄相關字）。"""
+        """字型快取失效後重繪依字型解析的顯示區（搜尋框、預覽、左欄詳資、
+        右欄相關字、中欄列表）。
+
+        各步驟獨立防護：任一區重繪失敗不牽連其餘（整包吞錯會讓熱更新
+        半途而廢且無從察覺是哪一段死掉）。
+        """
         if getattr(self, "w", None) is None:
             return  # __init__ 首次掃描時視窗尚未建立
         try:
             self._update_search_field_font()
-            char = self._right_panel_char or self.current_char
-            if char:
-                self.update_preview(char)
-                self.update_related_display()
+        except Exception:
+            pass
+        try:
+            # 預覽以 update_preview 記錄的當前顯示字重播（不重新推導，
+            # 避免 sticky 造成換字副作用）
+            if self._preview_char:
+                self.update_preview(self._preview_char)
+        except Exception:
+            pass
+        try:
+            # 左欄 textStorage 字型屬性一次性烙入、不會 draw-time 重解析：
+            # 以自身純文字重放（兩條寫入路徑簽名相同，字串即完整狀態）
+            text_view = self.w.content.getNSTextView()
+            text = str(text_view.textStorage().string())
+            if text:
+                text_view.textStorage().setAttributedString_(
+                    self.create_attributed_string(text, CONTENT_FONT_SIZE)
+                )
+        except Exception:
+            pass
+        try:
+            # 右欄重設 textStorage 會清掉使用者選取（連動禁用插入鈕）；
+            # 內容相同、只換字型，先存後還原選取範圍
+            text_view = self.w.relatedChars.getNSTextView()
+            selected = text_view.selectedRanges()
+            self.update_related_display()
+            text_view.setSelectedRanges_(selected)
+        except Exception:
+            pass
+        try:
             self.w.resultList.getNSTableView().setNeedsDisplay_(True)
         except Exception:
             pass

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -200,6 +200,13 @@ def choose_glyph_font_source(
     return None
 
 
+# font_and_source_for_char（UI 層）來源標記的 canonical 字彙：前三項由
+# choose_glyph_font_source 決定，'cascade'/'system' 由 UI 層 fallback 賦予。
+# 新增 tier 必須同步 localization 的 font_source_* 鍵
+#（tests/test_font_source_strings.py 鎖定對應）。
+FONT_SOURCES = ("folder", "family", "covering", "cascade", "system")
+
+
 def is_pua(code_point: int) -> bool:
     """碼位是否屬於私有使用區（BMP E000–F8FF、Plane 15/16，不含 noncharacter 尾端）。
 
@@ -226,21 +233,23 @@ def is_font_file_name(name: str) -> bool:
 
 
 def fonts_folder_snapshot(entries) -> Tuple:
-    """參考字型資料夾內容快照：(檔名, mtime) 序列 → 排序後 tuple。
+    """參考字型資料夾內容快照：(檔名, meta) 序列 → 排序後 tuple。
 
     熱更新判定依據：前後快照不相等即資料夾有變動（新增/移除/重新匯出），
-    上層據此清字型快取重新解析。只納入字型檔、忽略隱藏檔；排序使結果
-    與 os.scandir 的不定順序無關。
+    上層據此清字型快取重新解析。meta 為可排序、可比較的檔案識別——UI 層傳
+    (st_mtime_ns, st_size)，兩維並用可偵測 mtime 保留式覆蓋（cp -p、同步工具）。
+    只納入字型檔、忽略隱藏檔；排序使結果與 os.scandir 的不定順序無關。
     """
     return tuple(
         sorted(
-            (name, mtime) for name, mtime in entries if is_font_file_name(name)
+            (name, meta) for name, meta in entries if is_font_file_name(name)
         )
     )
 
 
 class FontCache:
-    """get_font_for_char 的字型快取：正向（鍵→字型）與負向（鍵→已知無涵蓋字型）。
+    """字型解析快取：正向（鍵→不透明 value，UI 層目前存 (font, source) tuple）
+    與負向（鍵→已知無涵蓋字型）。
 
     負向快取是效能關鍵：某 PUA 碼位無任何已安裝字型涵蓋時，若不記住，中欄 cell
     每次重繪都會重跑全字型暴力掃描造成捲動卡頓。負向項視為暫時性（使用者可能稍後

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -232,6 +232,15 @@ def is_font_file_name(name: str) -> bool:
     return not name.startswith(".") and name.lower().endswith(FONT_FILE_EXTENSIONS)
 
 
+def is_private_font_name(name: Optional[str]) -> bool:
+    """字型家族名是否為系統私有名（以 '.' 開頭，如 .AppleSystemUIFont、.SF NS）。
+
+    這類名字是 Apple 內部字型、只有系統 cascade 找得到、不應洩漏給使用者。
+    預覽 tooltip 在 cascade 命中隱藏系統字型時以此改用通用名（#26）。
+    """
+    return bool(name) and name.startswith(".")
+
+
 def fonts_folder_snapshot(entries) -> Tuple:
     """參考字型資料夾內容快照：(檔名, meta) 序列 → 排序後 tuple。
 

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/hanzi_core.py
@@ -108,15 +108,6 @@ def resolve_display_char(
     return sticky or current
 
 
-def _is_pua(code_point: int) -> bool:
-    """是否為 Private Use Area 碼位（BMP PUA 與兩個補充平面 PUA）。"""
-    return (
-        0xE000 <= code_point <= 0xF8FF
-        or 0xF0000 <= code_point <= 0xFFFFD
-        or 0x100000 <= code_point <= 0x10FFFD
-    )
-
-
 def field_display_char(text: Optional[str]) -> Optional[str]:
     """決定搜尋框（NSSearchField）該以哪個字的字型渲染，無則回 None（用系統字型）。
 
@@ -134,7 +125,7 @@ def field_display_char(text: Optional[str]) -> Optional[str]:
     if not stripped:
         return None
     for ch in stripped:
-        if _is_pua(ord(ch)):
+        if is_pua(ord(ch)):
             return ch
     if all(ord(ch) > 127 for ch in stripped):
         return stripped[0]
@@ -188,22 +179,64 @@ def utf16_len(text: str) -> int:
 
 
 def choose_glyph_font_source(
-    family_covers: bool, covering_found: bool
+    folder_covers: bool, family_covers: bool, covering_found: bool
 ) -> Optional[str]:
-    """PUA 缺字字型解析的優先序：回 'family' / 'covering' / None。
+    """PUA 缺字字型解析的優先序：回 'folder' / 'family' / 'covering' / None。
 
-    1) 當前文件同名安裝字型確實涵蓋 → 'family'（編輯中優先）；
-    2) 否則有其他已安裝字型涵蓋 → 'covering'；
-    3) 都沒有 → None（退系統字型、由負向快取記住待重試）。
+    1) 參考字型資料夾內有字型涵蓋 → 'folder'（使用者明確放入的覆蓋意圖，最優先）；
+    2) 當前文件同名安裝字型確實涵蓋 → 'family'（編輯中優先）；
+    3) 否則有其他已安裝字型涵蓋 → 'covering'；
+    4) 都沒有 → None（退系統字型、由負向快取記住待重試）。
 
-    第 3 步必為 None，不可退回「已確認不涵蓋」的同名字型——否則上層會把它當正向
+    末步必為 None，不可退回「已確認不涵蓋」的同名字型——否則上層會把它當正向
     結果快取（sticky 豆腐、forget_missing 清不掉）。見 [[FontCache]] 負向快取設計。
     """
+    if folder_covers:
+        return "folder"
     if family_covers:
         return "family"
     if covering_found:
         return "covering"
     return None
+
+
+def is_pua(code_point: int) -> bool:
+    """碼位是否屬於私有使用區（BMP E000–F8FF、Plane 15/16，不含 noncharacter 尾端）。
+
+    PUA 的字型涵蓋各自為政、系統 cascade 的挑選本質上任意（#26：DIN 搶走造字顯示），
+    get_font_for_char 以此分流：PUA 跳過 CTFontCreateForString，直接走明確優先序解析。
+    """
+    return (
+        0xE000 <= code_point <= 0xF8FF
+        or 0xF0000 <= code_point <= 0xFFFFD
+        or 0x100000 <= code_point <= 0x10FFFD
+    )
+
+
+FONT_FILE_EXTENSIONS = (".otf", ".ttf", ".ttc", ".otc")
+
+
+def is_font_file_name(name: str) -> bool:
+    """檔名是否為應納入參考字型資料夾的字型檔（忽略隱藏檔、副檔名不分大小寫）。
+
+    供 fonts_folder_snapshot 與 UI 層的 scandir 迴圈共用——後者在 stat 前
+    先以此過濾，略過 .DS_Store 等非字型檔的 syscall。
+    """
+    return not name.startswith(".") and name.lower().endswith(FONT_FILE_EXTENSIONS)
+
+
+def fonts_folder_snapshot(entries) -> Tuple:
+    """參考字型資料夾內容快照：(檔名, mtime) 序列 → 排序後 tuple。
+
+    熱更新判定依據：前後快照不相等即資料夾有變動（新增/移除/重新匯出），
+    上層據此清字型快取重新解析。只納入字型檔、忽略隱藏檔；排序使結果
+    與 os.scandir 的不定順序無關。
+    """
+    return tuple(
+        sorted(
+            (name, mtime) for name, mtime in entries if is_font_file_name(name)
+        )
+    )
 
 
 class FontCache:

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/localization.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/localization.py
@@ -135,6 +135,61 @@ STRINGS = {
         "zh-Hans": "依与当前字的笔画差筛选相关字",
         "ja": "現在の字との画数差で関連字をフィルター",
     },
+    # 參考字型資料夾（#26）
+    "menu_ref_fonts_empty": {
+        "en": "Reference Fonts: None",
+        "zh-Hant": "參考字型：無",
+        "zh-Hans": "参考字体：无",
+        "ja": "参照フォント：なし",
+    },
+    "menu_ref_fonts_count": {
+        "en": "Reference Fonts: {count}",
+        "zh-Hant": "參考字型：{count} 個檔案",
+        "zh-Hans": "参考字体：{count} 个文件",
+        "ja": "参照フォント：{count} 個",
+    },
+    "menu_open_ref_fonts_folder": {
+        "en": "Open Reference Fonts Folder...",
+        "zh-Hant": "開啟參考字型資料夾...",
+        "zh-Hans": "打开参考字体文件夹...",
+        "ja": "参照フォントフォルダを開く...",
+    },
+    "tooltip_display_font": {
+        "en": "Display font: {name} ({source})",
+        "zh-Hant": "顯示字型：{name}（{source}）",
+        "zh-Hans": "显示字体：{name}（{source}）",
+        "ja": "表示フォント：{name}（{source}）",
+    },
+    "font_source_folder": {
+        "en": "reference folder",
+        "zh-Hant": "參考資料夾",
+        "zh-Hans": "参考文件夹",
+        "ja": "参照フォルダ",
+    },
+    "font_source_family": {
+        "en": "installed, matches current document",
+        "zh-Hant": "已安裝・同當前文件",
+        "zh-Hans": "已安装・同当前文件",
+        "ja": "インストール済み・現在の書類と同名",
+    },
+    "font_source_covering": {
+        "en": "installed",
+        "zh-Hant": "已安裝",
+        "zh-Hans": "已安装",
+        "ja": "インストール済み",
+    },
+    "font_source_cascade": {
+        "en": "system cascade",
+        "zh-Hant": "系統自動選擇",
+        "zh-Hans": "系统自动选择",
+        "ja": "システム自動選択",
+    },
+    "font_source_system": {
+        "en": "system font",
+        "zh-Hant": "系統字型",
+        "zh-Hans": "系统字体",
+        "ja": "システムフォント",
+    },
 }
 
 

--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/localization.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/localization.py
@@ -10,6 +10,9 @@ Hanzi Component Explorer - 本地化字串模組
 
 from __future__ import division, print_function, unicode_literals
 
+# 支援語言（tests/test_font_source_strings.py 以此驗證所有字串鍵語言齊備）
+LANGUAGES = ("en", "zh-Hant", "zh-Hans", "ja")
+
 # 本地化字串字典
 STRINGS = {
     # 視窗與標題
@@ -143,10 +146,16 @@ STRINGS = {
         "ja": "参照フォント：なし",
     },
     "menu_ref_fonts_count": {
-        "en": "Reference Fonts: {count}",
+        "en": "Reference Fonts: {count} file(s)",
         "zh-Hant": "參考字型：{count} 個檔案",
         "zh-Hans": "参考字体：{count} 个文件",
         "ja": "参照フォント：{count} 個",
+    },
+    "menu_ref_fonts_count_failed": {
+        "en": "Reference Fonts: {count} file(s), {failed} failed to load",
+        "zh-Hant": "參考字型：{count} 個檔案（{failed} 個載入失敗）",
+        "zh-Hans": "参考字体：{count} 个文件（{failed} 个加载失败）",
+        "ja": "参照フォント：{count} 個（{failed} 個読み込み失敗）",
     },
     "menu_open_ref_fonts_folder": {
         "en": "Open Reference Fonts Folder...",
@@ -159,6 +168,12 @@ STRINGS = {
         "zh-Hant": "顯示字型：{name}（{source}）",
         "zh-Hans": "显示字体：{name}（{source}）",
         "ja": "表示フォント：{name}（{source}）",
+    },
+    "tooltip_font_missing": {
+        "en": "No installed or reference font covers this character",
+        "zh-Hant": "無已安裝或參考字型涵蓋此字",
+        "zh-Hans": "无已安装或参考字体涵盖此字",
+        "ja": "この文字を含むフォントがありません",
     },
     "font_source_folder": {
         "en": "reference folder",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@
 3. 查看拆解結果、同字根、衍生字
 4. 輸入多個部件（如「氵木」）搜尋同時包含所有部件的字：中欄列出輸入部件、右欄列出符合的字；此時筆畫篩選以各部件筆畫加總為基準（如「氵木」= 7 畫）
 
+### 參考字型資料夾（PUA 造字顯示）
+
+造字（PUA）的顯示字型優先序：參考字型資料夾 → 與當前文件同名的已安裝字型 → 其他已安裝字型。開發中的字型不必安裝，放進參考資料夾即可：
+
+1. 右下角篩選選單 > *開啟參考字型資料夾...*（位於 `~/Library/Application Support/Glyphs 3/HanziIDSComponentExplorer/Fonts/`）
+2. 放入字型檔（.otf / .ttf / .ttc / .otc）
+3. 切回工具視窗即生效；重新匯出覆蓋同檔名也會自動更新，不受 macOS 字型快取影響
+
 ## 系統需求
 
 - Glyphs 3.0 或以上
@@ -111,6 +119,14 @@ Download `HanziIDSComponentExplorer.glyphsPlugin` and double-click to install.
 2. Enter a Chinese character (e.g., "森") or Unicode (e.g., "68EE")
 3. View decomposition, sister characters, and derived characters
 4. Enter multiple components (e.g. "氵木") to find characters containing all of them: the middle column lists the input components, the right column lists the matches; stroke filtering then uses the sum of the components' stroke counts as the baseline (e.g. "氵木" = 7 strokes)
+
+### Reference Fonts Folder (PUA display)
+
+PUA glyphs resolve their display font in this order: reference fonts folder → installed font matching the current document's family name → other installed fonts. Fonts under development don't need to be installed — drop them into the reference folder:
+
+1. Bottom-right filter menu > *Open Reference Fonts Folder...* (located at `~/Library/Application Support/Glyphs 3/HanziIDSComponentExplorer/Fonts/`)
+2. Place font files (.otf / .ttf / .ttc / .otc) in the folder
+3. Switch back to the tool window to apply; re-exporting over the same file name also updates automatically, unaffected by the macOS font cache
 
 ## Requirements
 

--- a/tests/test_choose_glyph_font_source.py
+++ b/tests/test_choose_glyph_font_source.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 """choose_glyph_font_source：PUA 缺字字型解析的優先序決策純函式（TDD）。
 
-_resolve_glyph_font 的三段優先序：
-1) 當前文件同名安裝字型「確實涵蓋」此碼位 → 用它（編輯中優先）；
-2) 否則掃所有已安裝字型取涵蓋此碼位者 → 用它（與開哪個檔無關）；
-3) 都沒有 → None（退系統字型、由負向快取記住待重試）。
+_resolve_glyph_font 的四段優先序（#26 新增 folder tier）：
+1) 參考字型資料夾內有字型涵蓋此碼位 → 用它（使用者明確意圖，蓋過一切自動推斷）；
+2) 當前文件同名安裝字型「確實涵蓋」此碼位 → 用它（編輯中優先）；
+3) 否則掃所有已安裝字型取涵蓋此碼位者 → 用它（與開哪個檔無關）；
+4) 都沒有 → None（退系統字型、由負向快取記住待重試）。
 
-健檢 #1 相扣修正：原第 3 步誤回「已確認不涵蓋」的同名字型，會被 get_font_for_char
+健檢 #1 相扣修正：原末步誤回「已確認不涵蓋」的同名字型，會被 get_font_for_char
 當正向結果 store()（sticky 豆腐、forget_missing 清不掉）。正確應回 None 走 store_missing。
 """
 
@@ -26,18 +27,26 @@ from hanzi_core import choose_glyph_font_source  # noqa: E402
 
 
 class TestChooseGlyphFontSource:
-    """choose_glyph_font_source(family_covers, covering_found) → 'family'|'covering'|None。"""
+    """choose_glyph_font_source(folder_covers, family_covers, covering_found)
+    → 'folder'|'family'|'covering'|None。"""
+
+    def test_folder_covers_uses_folder(self):
+        assert choose_glyph_font_source(True, False, False) == "folder"
+
+    def test_folder_takes_priority_over_family_and_covering(self):
+        # 資料夾是使用者明確放入的覆蓋意圖，優先於文件同名字型與已安裝字型
+        assert choose_glyph_font_source(True, True, True) == "folder"
 
     def test_family_covers_uses_family(self):
-        assert choose_glyph_font_source(True, False) == "family"
+        assert choose_glyph_font_source(False, True, False) == "family"
 
     def test_family_covers_takes_priority_over_covering(self):
         # 文件同名字型涵蓋時優先，即使另有涵蓋字型
-        assert choose_glyph_font_source(True, True) == "family"
+        assert choose_glyph_font_source(False, True, True) == "family"
 
     def test_covering_found_when_family_not_cover(self):
-        assert choose_glyph_font_source(False, True) == "covering"
+        assert choose_glyph_font_source(False, False, True) == "covering"
 
     def test_none_when_nothing_covers(self):
         # 回歸核心：都不涵蓋 → None（不可退回不涵蓋的同名字型）
-        assert choose_glyph_font_source(False, False) is None
+        assert choose_glyph_font_source(False, False, False) is None

--- a/tests/test_font_source_strings.py
+++ b/tests/test_font_source_strings.py
@@ -3,8 +3,10 @@
 """字型來源字彙 ↔ localization 鍵護欄（#26）。
 
 font_and_source_for_char 的來源標記以 "font_source_" + source 組 localization
-鍵；缺鍵時 L() 靜默退回鍵名字面（tooltip 會顯示 font_source_xxx）。此測試
-鎖住每個來源都有對應字串鍵、且四種語言齊備——新增 tier 時忘加字串會在此爆。
+鍵；缺鍵時 L() 靜默退回鍵名字面（tooltip 會顯示 font_source_xxx）。來源字彙
+的 canonical 清單在 hanzi_core.FONT_SOURCES、語言清單在 localization.LANGUAGES
+——兩端皆 import 而非手抄，新增 tier 或語言時護欄自動擴及。
+語言齊備檢查涵蓋「全部」字串鍵，不只 font_source_*（invariant 是全域的）。
 """
 
 import sys
@@ -18,11 +20,8 @@ PLUGIN_RESOURCES = (
 )
 sys.path.insert(0, str(PLUGIN_RESOURCES))
 
-from localization import STRINGS  # noqa: E402
-
-# font_and_source_for_char（glyphs_ui.py）回傳的全部來源標記
-FONT_SOURCES = ("folder", "family", "covering", "cascade", "system")
-LANGUAGES = ("en", "zh-Hant", "zh-Hans", "ja")
+from hanzi_core import FONT_SOURCES  # noqa: E402
+from localization import LANGUAGES, STRINGS  # noqa: E402
 
 
 class TestFontSourceStrings:
@@ -30,8 +29,9 @@ class TestFontSourceStrings:
         for source in FONT_SOURCES:
             assert "font_source_" + source in STRINGS, source
 
-    def test_every_source_string_covers_all_languages(self):
-        for source in FONT_SOURCES:
-            entry = STRINGS["font_source_" + source]
+
+class TestAllStringsCoverAllLanguages:
+    def test_every_key_covers_every_language(self):
+        for key, entry in STRINGS.items():
             for lang in LANGUAGES:
-                assert entry.get(lang), (source, lang)
+                assert entry.get(lang), (key, lang)

--- a/tests/test_font_source_strings.py
+++ b/tests/test_font_source_strings.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""字型來源字彙 ↔ localization 鍵護欄（#26）。
+
+font_and_source_for_char 的來源標記以 "font_source_" + source 組 localization
+鍵；缺鍵時 L() 靜默退回鍵名字面（tooltip 會顯示 font_source_xxx）。此測試
+鎖住每個來源都有對應字串鍵、且四種語言齊備——新增 tier 時忘加字串會在此爆。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from localization import STRINGS  # noqa: E402
+
+# font_and_source_for_char（glyphs_ui.py）回傳的全部來源標記
+FONT_SOURCES = ("folder", "family", "covering", "cascade", "system")
+LANGUAGES = ("en", "zh-Hant", "zh-Hans", "ja")
+
+
+class TestFontSourceStrings:
+    def test_every_source_has_localization_key(self):
+        for source in FONT_SOURCES:
+            assert "font_source_" + source in STRINGS, source
+
+    def test_every_source_string_covers_all_languages(self):
+        for source in FONT_SOURCES:
+            entry = STRINGS["font_source_" + source]
+            for lang in LANGUAGES:
+                assert entry.get(lang), (source, lang)

--- a/tests/test_fonts_folder_snapshot.py
+++ b/tests/test_fonts_folder_snapshot.py
@@ -52,6 +52,12 @@ class TestFontsFolderSnapshot:
         after = fonts_folder_snapshot([("a.otf", 2.0)])
         assert before != after
 
+    def test_meta_tuple_size_change_changes_snapshot(self):
+        # UI 層傳 (st_mtime_ns, st_size)：mtime 保留式覆蓋（cp -p）靠 size 維度偵測
+        before = fonts_folder_snapshot([("a.otf", (100, 2048))])
+        after = fonts_folder_snapshot([("a.otf", (100, 4096))])
+        assert before != after
+
     def test_added_file_changes_snapshot(self):
         before = fonts_folder_snapshot([("a.otf", 1.0)])
         after = fonts_folder_snapshot([("a.otf", 1.0), ("b.otf", 1.0)])

--- a/tests/test_fonts_folder_snapshot.py
+++ b/tests/test_fonts_folder_snapshot.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""fonts_folder_snapshot：參考字型資料夾內容快照純函式（TDD，#26）。
+
+熱更新機制的核心：UI 層列出資料夾的 (檔名, mtime) 交給此函式組快照，
+前後快照不相等即代表資料夾有變動 → 清字型快取重新解析。
+只納入字型檔（.otf/.ttf/.ttc/.otc，副檔名不分大小寫），忽略隱藏檔與其他檔案；
+輸出排序後的 tuple，與輸入順序無關（os.scandir 順序不保證）。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import fonts_folder_snapshot  # noqa: E402
+
+
+class TestFontsFolderSnapshot:
+    def test_empty_folder_gives_empty_snapshot(self):
+        assert fonts_folder_snapshot([]) == ()
+
+    def test_filters_non_font_files(self):
+        entries = [("MyFont.otf", 1.0), ("readme.txt", 2.0), ("notes.md", 3.0)]
+        assert fonts_folder_snapshot(entries) == (("MyFont.otf", 1.0),)
+
+    def test_ignores_hidden_files(self):
+        entries = [(".DS_Store", 1.0), (".hidden.otf", 2.0), ("A.otf", 3.0)]
+        assert fonts_folder_snapshot(entries) == (("A.otf", 3.0),)
+
+    def test_extension_case_insensitive(self):
+        entries = [("A.OTF", 1.0), ("b.TtF", 2.0)]
+        assert fonts_folder_snapshot(entries) == (("A.OTF", 1.0), ("b.TtF", 2.0))
+
+    def test_accepts_collection_formats(self):
+        entries = [("a.ttc", 1.0), ("b.otc", 2.0)]
+        assert fonts_folder_snapshot(entries) == (("a.ttc", 1.0), ("b.otc", 2.0))
+
+    def test_order_independent_of_input_order(self):
+        forward = fonts_folder_snapshot([("a.otf", 1.0), ("b.otf", 2.0)])
+        backward = fonts_folder_snapshot([("b.otf", 2.0), ("a.otf", 1.0)])
+        assert forward == backward
+
+    def test_mtime_change_changes_snapshot(self):
+        before = fonts_folder_snapshot([("a.otf", 1.0)])
+        after = fonts_folder_snapshot([("a.otf", 2.0)])
+        assert before != after
+
+    def test_added_file_changes_snapshot(self):
+        before = fonts_folder_snapshot([("a.otf", 1.0)])
+        after = fonts_folder_snapshot([("a.otf", 1.0), ("b.otf", 1.0)])
+        assert before != after

--- a/tests/test_is_private_font_name.py
+++ b/tests/test_is_private_font_name.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""is_private_font_name：系統私有字型家族名判定純函式（TDD，#26）。
+
+Apple 內部字型家族名以 '.' 開頭（.AppleSystemUIFont、.SF NS 等），只有系統
+cascade 找得到、不應洩漏給使用者。預覽 tooltip 以此在 cascade 命中隱藏系統
+字型時改用通用名，避免洩漏私有名（PR #28 review ③；先前僅 'system' 來源有防護）。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import is_private_font_name  # noqa: E402
+
+
+class TestIsPrivateFontName:
+    def test_apple_system_ui_font_is_private(self):
+        assert is_private_font_name(".AppleSystemUIFont")
+
+    def test_sf_ns_is_private(self):
+        assert is_private_font_name(".SF NS")
+
+    def test_dot_prefixed_is_private(self):
+        assert is_private_font_name(".LastResort")
+
+    def test_visible_family_is_not_private(self):
+        assert not is_private_font_name("Songti SC")
+
+    def test_none_is_not_private(self):
+        assert not is_private_font_name(None)
+
+    def test_empty_is_not_private(self):
+        assert not is_private_font_name("")

--- a/tests/test_is_pua.py
+++ b/tests/test_is_pua.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""is_pua：私有使用區碼位判定純函式（TDD，#26）。
+
+PUA 碼位的字型解析不可信任系統 cascade（任何字型對 PUA 的涵蓋都是各自為政），
+get_font_for_char 以此函式將 PUA 分流到明確優先序路徑。
+範圍：BMP U+E000–F8FF、Plane 15 U+F0000–FFFFD、Plane 16 U+100000–10FFFD
+（各補充平面最末兩碼位為 noncharacter，不含）。
+"""
+
+import sys
+from pathlib import Path
+
+PLUGIN_RESOURCES = (
+    Path(__file__).parent.parent
+    / "HanziIDSComponentExplorer.glyphsPlugin"
+    / "Contents"
+    / "Resources"
+)
+sys.path.insert(0, str(PLUGIN_RESOURCES))
+
+from hanzi_core import is_pua  # noqa: E402
+
+
+class TestIsPuaBmp:
+    def test_bmp_pua_start(self):
+        assert is_pua(0xE000)
+
+    def test_bmp_pua_end(self):
+        assert is_pua(0xF8FF)
+
+    def test_below_bmp_pua_is_not(self):
+        assert not is_pua(0xDFFF)
+
+    def test_compat_ideograph_above_bmp_pua_is_not(self):
+        assert not is_pua(0xF900)
+
+
+class TestIsPuaSupplementary:
+    def test_plane15_start(self):
+        assert is_pua(0xF0000)
+
+    def test_plane15_end(self):
+        assert is_pua(0xFFFFD)
+
+    def test_plane15_noncharacter_excluded(self):
+        assert not is_pua(0xFFFFE)
+
+    def test_plane16_start(self):
+        assert is_pua(0x100000)
+
+    def test_plane16_end(self):
+        assert is_pua(0x10FFFD)
+
+    def test_plane16_noncharacter_excluded(self):
+        assert not is_pua(0x10FFFE)
+
+    def test_below_plane15_is_not(self):
+        assert not is_pua(0xEFFFF)
+
+
+class TestIsPuaCommonChars:
+    def test_cjk_unified_is_not(self):
+        assert not is_pua(0x4E00)
+
+    def test_ascii_is_not(self):
+        assert not is_pua(0x41)
+
+    def test_cjk_ext_b_is_not(self):
+        assert not is_pua(0x20000)


### PR DESCRIPTION
## Summary

修正使用者回報的「PUA 造字被 DIN 等已安裝字型搶走顯示」問題（Closes #26）。

- **根因修正**：PUA 碼位跳過系統 cascade（其挑選本質任意），改走明確優先序：參考資料夾 → 當前文件同名安裝字型 → 已安裝涵蓋字型 → 系統字型（負向快取）
- **參考字型資料夾**：`~/Library/Application Support/Glyphs 3/HanziIDSComponentExplorer/Fonts/`，`CTFontManagerCreateFontDescriptorsFromURL` 直接讀檔不註冊——與同名安裝字型不衝突、不受 macOS 字型快取影響，開發中重新匯出即生效
- **熱更新**：became key／搜尋／開選單三時點比對 mtime 快照，變動即由 `_rescan_fonts_folder` 集中失效（字型快取＋搜尋框字型 memo）並重繪
- **效能**：charset 載入時預取（涵蓋判定不逐次建字型）、descriptors lazy 載入（啟動不阻塞）、快取命中路徑零配置
- **可觀察性**：預覽區 tooltip 顯示解析到的字型與來源；篩選選單新增「參考字型：N 個檔案」資訊列與「開啟參考字型資料夾...」入口（四語）

## UI scope（明確不做）

字型清單管理視窗、手動重掃按鈕、偏好設定視窗——資料夾即介面，空資料夾＝功能不啟用。

## Test plan

- [x] 純邏輯 TDD：`is_pua`（收斂既有 `_is_pua` 重複）、`fonts_folder_snapshot`、`is_font_file_name`、`choose_glyph_font_source` folder tier、font source localization 護欄——169 passed / 11 skipped
- [x] CoreText API smoke test（Glyphs 自帶 Python 3.11）：descriptor 讀檔、涵蓋判定、familyName bridging
- [x] 實機驗證（回報者情境）：資料夾字型生效、重新匯出熱更新、搜尋框字型同步替換

🤖 Generated with [Claude Code](https://claude.com/claude-code)