### PR TITLE
fix(#27): 移除預覽區寫死 baseline_offset -4（最小減法）

### DIFF
--- a/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
+++ b/HanziIDSComponentExplorer.glyphsPlugin/Contents/Resources/glyphs_ui.py
@@ -23,7 +23,6 @@ from AppKit import (
     NSForegroundColorAttributeName,
     NSKernAttributeName,
     NSParagraphStyleAttributeName,
-    NSBaselineOffsetAttributeName,
     NSMutableParagraphStyle,
     NSColor,
     NSOpenPanel,
@@ -1758,11 +1757,9 @@ class HanziComponentSearchTool:
         font, source = self.font_and_source_for_char(char)
         self._set_preview_tooltip(font, source)
 
-        # 垂直偏移量：負值向下移動，正值向上移動
-        # 微調讓文字在 90px 高度區域內視覺居中
-        baseline_offset = -4
-
-        # 段落樣式：水平居中
+        # 不套 NSBaselineOffset：實測系統字型在預設（offset 0）即視覺置中，
+        # 舊的 -4 反而偏低 4pt。正 offset 對 top-pinned 單行無效、無法用它校正
+        # 大 ascender 手寫體（Hannotate 類需依實際墨跡邊界自訂繪製，見 #27）。
         paragraph_style = NSMutableParagraphStyle.alloc().init()
         paragraph_style.setAlignment_(1)  # NSCenterTextAlignment = 1
 
@@ -1772,7 +1769,6 @@ class HanziComponentSearchTool:
             {
                 NSFontAttributeName: font,
                 NSForegroundColorAttributeName: NSColor.labelColor(),
-                NSBaselineOffsetAttributeName: baseline_offset,
                 NSParagraphStyleAttributeName: paragraph_style,
             },
         )


### PR DESCRIPTION
## 背景
#27 回報 Hannotate 等大 ascender 手寫體在預覽區偏位。用 Swift/NSTextField probe（90pt box、72pt 字、量實際墨跡中心）實測後發現：**#27 原規劃的 `preview_baseline_offset(ascender, descender, box_height)` 方案行不通**——Hannotate 需要往上移，而正 NSBaselineOffset 對 top-pinned 單行無效；且 (ascender, descender) 連墨跡落點都表達不了。

## 本次（最小減法）
移除寫死的 `baseline_offset = -4`：實測顯示它反而把系統字型墨跡中心推到 40.5（低 4pt），移除後回到 44.5（≈45 正中）。

| 字型 | 舊 -4 | 新（移除） |
|------|------|------|
| 系統「漢」 | 40.5 | **44.5 ✅** |
| STHeiti「書」 | 50.5 | 54.5（略高）|
| Hannotate「書」 | 33.0 | 35.75（仍低）|

## 尚未解（#27 保持開啟）
Hannotate 類與短 ascender CJK 都需改**依實際墨跡邊界自訂繪製**（拿掉 top-pinned TextBox，純函式 `box_height/2 - (ink_top+ink_bottom)/2`），兩方向才都可達。本 PR 僅修系統字型偏移，屬部分解。

需實機（Glyphs）目視確認預覽置中。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>